### PR TITLE
feat: MariaDB 의존성 추가

### DIFF
--- a/backend/rush/build.gradle
+++ b/backend/rush/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation 'org.springframework.security:spring-security-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-validation:2.4.3'
     runtimeOnly 'com.h2database:h2'
-    runtimeOnly("mysql:mysql-connector-java:8.0.17")
+    runtimeOnly("org.mariadb.jdbc:mariadb-java-client")
     annotationProcessor("org.projectlombok:lombok")
     compileOnly("org.projectlombok:lombok")
     implementation 'commons-codec:commons-codec:1.11'

--- a/backend/rush/src/main/java/rush/rush/RushApplication.java
+++ b/backend/rush/src/main/java/rush/rush/RushApplication.java
@@ -9,15 +9,8 @@ import rush.rush.security.AppProperties;
 @SpringBootApplication
 public class RushApplication {
 
-    private static final String APPLICATION_LOCATIONS = "spring.config.location="
-        + "classpath:application.yml,"
-        + "classpath:application-oauth.yml,"
-        + "classpath:application-local.yml,"
-        + "optional:/app/config/application-real.yml";
-
     public static void main(String[] args) {
         new SpringApplicationBuilder(RushApplication.class)
-            .properties(APPLICATION_LOCATIONS)
             .run(args);
     }
 }

--- a/backend/rush/src/main/java/rush/rush/RushApplication.java
+++ b/backend/rush/src/main/java/rush/rush/RushApplication.java
@@ -9,8 +9,15 @@ import rush.rush.security.AppProperties;
 @SpringBootApplication
 public class RushApplication {
 
+    private static final String APPLICATION_LOCATIONS = "spring.config.location="
+        + "classpath:application.yml,"
+        + "classpath:application-oauth.yml,"
+        + "classpath:application-local.yml,"
+        + "optional:/app/config/application-real.yml";
+
     public static void main(String[] args) {
         new SpringApplicationBuilder(RushApplication.class)
+            .properties(APPLICATION_LOCATIONS)
             .run(args);
     }
 }


### PR DESCRIPTION
**이슈 번호**

resolved: #61 

**작업 내용**

1. mariaDB 의존성 추가

     라즈베리파이에서 MySQL을 지원하지 않아서 MySQL을 쓸 수 없음.
    따라서 실서버 DB를 MySQL 에서 MariaDB 로 바꿀 필요가 있음.

**테스트 작성 여부**

- [ ] Test case

**주의 사항**