### PR TITLE
feat: 프론트엔드 포트번호 변경

### DIFF
--- a/frontend/rush/src/constants/ADDRESS.js
+++ b/frontend/rush/src/constants/ADDRESS.js
@@ -1,4 +1,4 @@
 export const BACKEND_ADDRESS = "http://seoultechfootprint.shop:8080";
-export const FRONTEND_ADDRESS = "http://seoultechfootprint.shop:3000";
+export const FRONTEND_ADDRESS = "http://seoultechfootprint.shop:80";
 // export const BACKEND_ADDRESS = "http://localhost:8080";
 // export const FRONTEND_ADDRESS = "http://localhost:3000";


### PR DESCRIPTION
**이슈 번호**

resolved: #74 

**작업 내용**

1. 라즈베리파이로 서버를 이전하면서 실서버 프론트엔드 포트번호를 3000 에서 80 으로 바꾸었기때문에 이를 반영함

**테스트 작성 여부**

- [ ] Test case

**주의 사항**