### PR TITLE
fix: 백엔드의 실서버 프론트앤드 주소에서 포트번호를 빼고 도메인만 쓰도록 변경

### DIFF
--- a/backend/rush/src/main/java/rush/rush/config/WebConfig.java
+++ b/backend/rush/src/main/java/rush/rush/config/WebConfig.java
@@ -8,7 +8,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
 
     private static final String DEVELOP_FRONT_ADDRESS = "http://localhost:3000";
-    private static final String REAL_FRONT_ADDRESS = "http://seoultechfootprint.shop:80";
+    private static final String REAL_FRONT_ADDRESS = "http://seoultechfootprint.shop";
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {


### PR DESCRIPTION
**이슈 번호**

resolved: #79 

**작업 내용**

1. 백엔드의 실서버 프론트앤드 주소에서 포트번호를 빼고 도메인만 쓰도록 변경

**테스트 작성 여부**

- [ ] Test case

**주의 사항**