### PR TITLE
refactor: article객체로 latitude, longitude를 얻어 article page에서 메인화면으로 보내도록 수정

### DIFF
--- a/frontend/rush/src/components/articleDetail/ArticleDetailPage.js
+++ b/frontend/rush/src/components/articleDetail/ArticleDetailPage.js
@@ -41,8 +41,8 @@ const ArticleDetailPage = (props) => {
                   imageUrl: ""
                 }}
                 createDate={article? article.createDate:""}
-                markerLat={props.location.state.lat}
-                markerLng={props.location.state.lng}
+                markerLat={article? article.latitude:""}
+                markerLng={article? article.longitude:""}
             />
             <ArticleBody article={article}/>
           </PostBox>

--- a/frontend/rush/src/components/home/DefaultMap.js
+++ b/frontend/rush/src/components/home/DefaultMap.js
@@ -43,7 +43,7 @@ const DefaultMap = withScriptjs(withGoogleMap((props) => {
           setInfoWindowPostId(null);
         }}
     >
-      <div onClick={() => props.history.push({pathname:'/articles/' + post.id, state:{lat: post.latitude, lng: post.longitude}})}>{post.title}</div>
+      <div onClick={() => props.history.push('/articles/' + post.id)}>{post.title}</div>
     </InfoWindow>}
   </Marker>);
 

--- a/frontend/rush/src/components/writing/CreateWritingApi.js
+++ b/frontend/rush/src/components/writing/CreateWritingApi.js
@@ -25,8 +25,7 @@ const createWritingApi = (props) => {
     .then(response => {
       if (response.status === 201) {
          const uri = response.headers.location;
-
-         props.history.push({pathname:uri, state:{lat:props.center.lat(), lng:props.center.lng()}});
+         props.history.push(uri);
       }
     })
     .catch(error => {


### PR DESCRIPTION
**이슈 번호**

resolved: #72 

**작업 내용**

1. article객체로 latitude, longitude를 얻어 article page에서 메인화면으로 보내도록 수정

**테스트 작성 여부**

- [ ] Test case

**주의 사항**