### PR TITLE
feat: 댓글 최신순 정렬 및 findAllByArticle() DB 조회 횟수 줄임

### DIFF
--- a/backend/rush/src/main/java/rush/rush/repository/CommentRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/CommentRepository.java
@@ -1,13 +1,9 @@
 package rush.rush.repository;
-
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import rush.rush.domain.Comment;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    @Query("select c from Comment c where c.article.id = :articleId order by c.createDate desc")
-    List<Comment> findAllByArticleId(@Param("articleId") Long articleId);
+    List<Comment> findAllByArticleIdOrderByCreateDateDesc(Long articleId);
 }

--- a/backend/rush/src/main/java/rush/rush/repository/CommentRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/CommentRepository.java
@@ -8,6 +8,6 @@ import rush.rush.domain.Comment;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    @Query("select c from Comment c where c.article.id = :articleId")
+    @Query("select c from Comment c where c.article.id = :articleId order by c.createDate desc")
     List<Comment> findAllByArticleId(@Param("articleId") Long articleId);
 }

--- a/backend/rush/src/main/java/rush/rush/repository/CommentRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/CommentRepository.java
@@ -2,10 +2,12 @@ package rush.rush.repository;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import rush.rush.domain.Article;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import rush.rush.domain.Comment;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    List<Comment> findAllByArticle(Article article);
+    @Query("select c from Comment c where c.article.id = :articleId")
+    List<Comment> findAllByArticleId(@Param("articleId") Long articleId);
 }

--- a/backend/rush/src/main/java/rush/rush/service/CommentService.java
+++ b/backend/rush/src/main/java/rush/rush/service/CommentService.java
@@ -1,5 +1,7 @@
 package rush.rush.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,9 +13,6 @@ import rush.rush.dto.CommentResponse;
 import rush.rush.dto.CreateCommentRequest;
 import rush.rush.repository.ArticleRepository;
 import rush.rush.repository.CommentRepository;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -35,12 +34,8 @@ public class CommentService {
 
     @Transactional
     public List<CommentResponse> findCommentsByArticleId(Long articleId) {
-        // todo: 쿼리가 다음과 같이 한번만 나가도록 수정
-        //       select * from Comment where articleId = {}
-        Article article = articleRepository.findById(articleId)
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 article ID 입니다."));
 
-        return commentRepository.findAllByArticle(article).stream()
+        return commentRepository.findAllByArticleId(articleId).stream()
             .map(this::toCommentResponse)
             .collect(Collectors.toList());
     }

--- a/backend/rush/src/main/java/rush/rush/service/CommentService.java
+++ b/backend/rush/src/main/java/rush/rush/service/CommentService.java
@@ -35,7 +35,7 @@ public class CommentService {
     @Transactional
     public List<CommentResponse> findCommentsByArticleId(Long articleId) {
 
-        return commentRepository.findAllByArticleId(articleId).stream()
+        return commentRepository.findAllByArticleIdOrderByCreateDateDesc(articleId).stream()
             .map(this::toCommentResponse)
             .collect(Collectors.toList());
     }

--- a/backend/rush/src/test/java/rush/rush/repository/CommentRepositoryTest.java
+++ b/backend/rush/src/test/java/rush/rush/repository/CommentRepositoryTest.java
@@ -38,20 +38,24 @@ class CommentRepositoryTest {
             .nickName("test")
             .provider(AuthProvider.local)
             .build();
-        user = testEntityManager.persist(user);
+        testEntityManager.persist(user);
 
         Article article = new Article("제목1", "내용내용", 37.14, 34.24, user);
-        article = testEntityManager.persist(article);
+        testEntityManager.persist(article);
 
-        Comment comment = new Comment(COMMENT_CONTENT, user, article);
-        comment = testEntityManager.persist(comment);
+        Comment comment1 = new Comment(COMMENT_CONTENT, user, article);
+        testEntityManager.persist(comment1);
+        Comment comment2 = new Comment(COMMENT_CONTENT, user, article);
+        testEntityManager.persist(comment2);
 
         // when
-        List<Comment> comments = commentRepository.findAllByArticleId(article.getId());
+        List<Comment> comments = commentRepository.findAllByArticleIdOrderByCreateDateDesc(article.getId());
         assertThat(comments).isNotNull();
-        assertThat(comments).hasSize(1);
+        assertThat(comments).hasSize(2);
         assertThat(comments.get(0).getContent()).isEqualTo(COMMENT_CONTENT);
         assertThat(comments.get(0).getUser().getId()).isEqualTo(user.getId());
         assertThat(comments.get(0).getArticle().getId()).isEqualTo(article.getId());
+        assertThat(comments.get(0).getId()).isEqualTo(comment2.getId());
+        assertThat(comments.get(1).getId()).isEqualTo(comment1.getId());
     }
 }

--- a/backend/rush/src/test/java/rush/rush/repository/CommentRepositoryTest.java
+++ b/backend/rush/src/test/java/rush/rush/repository/CommentRepositoryTest.java
@@ -1,5 +1,8 @@
 package rush.rush.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,10 +14,6 @@ import rush.rush.domain.Article;
 import rush.rush.domain.AuthProvider;
 import rush.rush.domain.Comment;
 import rush.rush.domain.User;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)  // junit5에게 Spring support를 enable 하라고 말하는거
 @DataJpaTest
@@ -48,7 +47,7 @@ class CommentRepositoryTest {
         comment = testEntityManager.persist(comment);
 
         // when
-        List<Comment> comments = commentRepository.findAllByArticle(article);
+        List<Comment> comments = commentRepository.findAllByArticleId(article.getId());
         assertThat(comments).isNotNull();
         assertThat(comments).hasSize(1);
         assertThat(comments.get(0).getContent()).isEqualTo(COMMENT_CONTENT);


### PR DESCRIPTION
**이슈 번호**

resolved: #67 #84  

**작업 내용**

1. Comment를 호출할 때 Article 객체를 가져오고 이 객체를 통해 Comment 객체를 가져오는 이차적인 코드를 ArticleId를 통해서 바로 Comment 객체를 가져오도록 수정
2. 댓글 날짜순으로 정렬
3. CommentRepository 테스트 수정

**테스트 작성 여부**

- [x] Test case

**주의 사항**