### PR TITLE
feat: 마이페이지 보충 구현

### DIFF
--- a/frontend/rush/src/components/myPage/MyPage.js
+++ b/frontend/rush/src/components/myPage/MyPage.js
@@ -8,12 +8,16 @@ import {ACCESS_TOKEN} from "../../constants/SessionStorage";
 import Profile from "./Profile";
 import Info from "./Info";
 import MyArticles from "./articles/MyArticles";
+import MyGroups from "./groups/MyGroups";
+import findMyGroupsApi from "../../api/FindMyGroupsApi";
 
 const MyPage = (props) => {
 
-  const [isOpened, setIsOpened] = useState(false);
+  const [isGroupsOpened, setIsGroupsOpened] = useState(false);
+  const [isArticlesOpened, setIsArticlesOpened] = useState(false);
   const [user, setUser] = useState(null);
   const [myArticles, setMyArticles] = useState(null);
+  const [myGroups, setMyGroups] = useState(null);
   const accessToken = sessionStorage.getItem(ACCESS_TOKEN);
 
   useEffect(() => {
@@ -21,11 +25,14 @@ const MyPage = (props) => {
       alert("로그인이 만료되었습니다. 다시 로그인해주세요.");
       props.history.push("/login");
     }
+    findMyGroupsApi(accessToken).then(groupsPromise=>{
+      setMyGroups(groupsPromise)
+    })
     findUserApi(accessToken).then(userPromise => {
     setUser(userPromise)
     });
-    findMyArticlesApi(accessToken).then(userPromise => {
-      setMyArticles(userPromise)
+    findMyArticlesApi(accessToken).then(articlesPromise => {
+      setMyArticles(articlesPromise)
     });
   }, [accessToken]);
 
@@ -42,8 +49,13 @@ const MyPage = (props) => {
           </StyledDiv>
           <MyArticles
               myArticles={myArticles}
-              isOpened={isOpened}
-              setIsOpened={setIsOpened}
+              isOpened={isArticlesOpened}
+              setIsOpened={setIsArticlesOpened}
+          />
+          <MyGroups
+              myGroups={myGroups}
+              isOpened={isGroupsOpened}
+              setIsOpened={setIsGroupsOpened}
           />
         </DisplayBox>
       </Outside>

--- a/frontend/rush/src/components/myPage/articles/ArticleContent.js
+++ b/frontend/rush/src/components/myPage/articles/ArticleContent.js
@@ -5,22 +5,42 @@ import {withRouter} from "react-router-dom";
 const ArticleContentStyle = styled.div`
   display: flex;
   justify: center;
-  height: 20px;
-  font-size: 13px;
-  margin-bottom: 6px;
+  height: 40px;
+  margin-bottom: 6px; 
   margin-left: 10px;
   border: 2px solid rgb(90, 155, 213);
   border-radius: 10px;
+  overflow-x: auto;
+  overflow-y: hidden;
+`;
+
+const StyledTitle = styled.div`
+  white-space : nowrap;  //텍스트길이가 길어짐에 따라 버튼의 가로길이를 자동으로 증가시킴
+  margin-top:5px;
+  border: 2px solid rgb(90, 155, 213);
+  border-radius: 10px;
+  height: 30px;
+  margin-left: 5px;
+  font-size: 15px;
+`;
+
+const StyledButton = styled.button`
+  white-space : nowrap;  //텍스트길이가 길어짐에 따라 버튼의 가로길이를 자동으로 증가시킴
+  margin-top:5px;
+  height: 30px;
+  margin-left: 5px;
+  font-size: 15px;
 `;
 
 const ArticleContent = (props) => {
-  console.log(props.article)
+
+  const groups= props.article.groups.map((group)=><StyledButton onClick={()=>{props.history.push('/articles/grouped/'+props.article.id)}}>{group.name}</StyledButton>);
   return (
-      <ArticleContentStyle onClick={()=>{props.history.push('/')}}>
-        {props.article.title}&nbsp;&nbsp;&nbsp;
-        {props.article.publicMap? " 전체지도":""}
-        {props.article.privateMap? " 개인지도":""}
-        {props.article.groups.length>=1? " 그룹리스트나열할예정":""}
+      <ArticleContentStyle >
+        <StyledTitle>{props.article.title}</StyledTitle>
+        {props.article.publicMap? <StyledButton onClick={()=>{props.history.push('/articles/public/'+props.article.id)}}> 전체지도 </StyledButton>:""}
+        {props.article.privateMap? <StyledButton onClick={()=>{props.history.push('/articles/private/'+props.article.id)}}>개인지도 </StyledButton>:""}
+        {props.article.groups.length>=1? groups:""}
       </ArticleContentStyle>
   );
 };

--- a/frontend/rush/src/components/myPage/groups/GroupContent.js
+++ b/frontend/rush/src/components/myPage/groups/GroupContent.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import styled from "styled-components";
+import {withRouter} from "react-router-dom";
+
+const GroupContentStyle = styled.div`
+  display: flex;
+  justify: center;
+  height: 40px;
+  margin-bottom: 6px; 
+  margin-left: 10px;
+  border: 2px solid rgb(90, 155, 213);
+  border-radius: 10px;
+  overflow-x: auto;
+  overflow-y: hidden;
+`;
+
+const StyledButton = styled.button`
+  white-space : nowrap;  //텍스트길이가 길어짐에 따라 버튼의 가로길이를 자동으로 증가시킴
+  margin-top:5px;
+  height: 30px;
+  margin-left: 5px;
+  font-size: 15px;
+`;
+
+const GroupContent = (props) => {
+
+  return (
+      <GroupContentStyle>
+        {props.group? <StyledButton onClick={()=>{props.history.push('/groups/'+props.group.id)}}> {props.group.name} </StyledButton>:""}
+      </GroupContentStyle>
+  );
+};
+
+export default withRouter(GroupContent);

--- a/frontend/rush/src/components/myPage/groups/GroupsList.js
+++ b/frontend/rush/src/components/myPage/groups/GroupsList.js
@@ -1,0 +1,39 @@
+import React, {useEffect, useState} from 'react';
+import {Motion, spring} from "react-motion";
+import GroupContent from "./GroupContent";
+
+
+const GroupsList = (props) => {
+  const [height, setHeight] = useState(0);
+
+  useEffect(() => {
+    setHeight(props.isOpened ? (50 * props.myGroups.length) : 0);
+  }, [props]);
+
+  const groupPresent = props.myGroups ? props.myGroups.map((group) =>
+      <GroupContent
+          group={group}
+          hitsory={props.history}
+      />
+  ) : "";
+
+  const styles = {
+    menu: {
+      overflow: 'hidden',
+    }
+  };
+
+  return (
+      <div className="App">
+        <Motion style={{height: spring(height)}}>
+          {
+            ({height}) => <div style={Object.assign({}, styles.menu, {height})}>
+              {groupPresent}
+            </div>
+          }
+        </Motion>
+      </div>
+  );
+};
+
+export default GroupsList;

--- a/frontend/rush/src/components/myPage/groups/GroupsList.js
+++ b/frontend/rush/src/components/myPage/groups/GroupsList.js
@@ -2,7 +2,6 @@ import React, {useEffect, useState} from 'react';
 import {Motion, spring} from "react-motion";
 import GroupContent from "./GroupContent";
 
-
 const GroupsList = (props) => {
   const [height, setHeight] = useState(0);
 

--- a/frontend/rush/src/components/myPage/groups/GroupsListOpenButton.js
+++ b/frontend/rush/src/components/myPage/groups/GroupsListOpenButton.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import styled from "styled-components";
+
+const StyledDiv = styled.div`
+  display: inline-block;
+`;
+
+const GroupsListOpenButton = (props) => {
+  return (
+      <StyledDiv onClick={() => props.setIsOpened(!props.isOpened)}>
+        {props.isOpened? "▲" : "▼"}
+      </StyledDiv>
+  );
+};
+
+export default GroupsListOpenButton;

--- a/frontend/rush/src/components/myPage/groups/MyGroups.js
+++ b/frontend/rush/src/components/myPage/groups/MyGroups.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import styled from "styled-components";
+import GroupsListOpenButton from "./GroupsListOpenButton";
+import GroupsList from "./GroupsList";
+
+const StyledElement = styled.div`
+  margin:10px 0;
+  font-size:19px;
+  padding: 4px 10px;
+`;
+const MyGroups = (props) => {
+  return (<>
+    <StyledElement
+        onClick={() => props.setIsOpened(!props.isOpened)}
+        style={{marginTop: '19px' }}
+    >
+      내 그룹 목록
+      <GroupsListOpenButton
+          isOpened={props.isOpened}
+          setIsOpened={props.setIsOpened}
+      />
+    </StyledElement>
+    <GroupsList
+        isOpened={props.isOpened}
+        myGroups={props.myGroups}
+    />
+  </>
+  )
+};
+
+export default MyGroups;


### PR DESCRIPTION
**이슈 번호**

resolved: #103 

**작업 내용**

1. 마이페이지에서 게시 글 리스트에 각 게시글 클릭시 해당 maptype의 게시 글로 이동하도록 구현
2. 마이페이지에 나의 그룹리스트 구현, 각 그룹 클릭시 해당 그룹페이지로 이동
![image](https://user-images.githubusercontent.com/45135492/125431051-6e591c71-0960-42a5-a548-3c667922674e.png)![image](https://user-images.githubusercontent.com/45135492/125430886-52d587c9-70bc-45c3-b413-c81eeb32b750.png)

**테스트 작성 여부**

- [ ] Test case

**해야할 것들**
디자인 구림, 프로필변경(위 사진에는 버튼만 표시한것뿐, 실제 push한 내용에는 저 버튼이 없음), 별명변경