### PR TITLE
feat: 그룹 페이지 구현

### DIFF
--- a/backend/rush/http/group.http
+++ b/backend/rush/http/group.http
@@ -12,12 +12,17 @@ POST http://localhost:8080/groups/join?invitation_code=aklsjdf2
 Content-Type: application/json
 Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjIwODkyNzE5LCJleHAiOjE2MjA4OTQ1M
 
-###
+### 내가 속한 그룹 목록 조회
 GET http://localhost:8080/groups/mine
 Content-Type: application/json
 Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjIwODkyNzE5LCJleHAiOjE2MjA4OTQ1M
 
-###
+### 그룹 상세 조회
 GET http://localhost:8080/groups/1
 Content-Type: application/json
 Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjI0ODcxMzY2LCJleHAiOjE2MjQ4NzMxN
+
+### 그룹 멤버 목록 조회
+GET http://localhost:8080/groups/1/members
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjI2NjgyMDg4LCJleHAiOjE2MjY2ODM4O

--- a/backend/rush/src/main/java/rush/rush/controller/GroupController.java
+++ b/backend/rush/src/main/java/rush/rush/controller/GroupController.java
@@ -1,17 +1,23 @@
 package rush.rush.controller;
 
+import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import rush.rush.dto.CreateGroupRequest;
 import rush.rush.dto.GroupResponse;
 import rush.rush.dto.GroupSummaryResponse;
+import rush.rush.dto.SimpleUserResponse;
 import rush.rush.security.CurrentUser;
 import rush.rush.security.user.UserPrincipal;
 import rush.rush.service.GroupService;
-
-import java.net.URI;
-import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -50,5 +56,13 @@ public class GroupController {
 
         return ResponseEntity.ok()
                 .body(groupResponse);
+    }
+
+    @GetMapping("/{id}/members")
+    public ResponseEntity<List<SimpleUserResponse>> findMembers(@PathVariable("id") Long groupId, @CurrentUser UserPrincipal userPrincipal) {
+        List<SimpleUserResponse> userResponses = groupService.findMembers(groupId, userPrincipal.getUser());
+
+        return ResponseEntity.ok()
+            .body(userResponses);
     }
 }

--- a/backend/rush/src/main/java/rush/rush/domain/Article.java
+++ b/backend/rush/src/main/java/rush/rush/domain/Article.java
@@ -5,6 +5,7 @@ import java.sql.Timestamp;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -39,7 +40,7 @@ public class Article {
     @NotNull
     private Double longitude;   // 경도
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "USER_ID", nullable = false)
     private User user;
 

--- a/backend/rush/src/main/java/rush/rush/domain/ArticleGroup.java
+++ b/backend/rush/src/main/java/rush/rush/domain/ArticleGroup.java
@@ -1,13 +1,18 @@
 package rush.rush.domain;
 
+import java.sql.Timestamp;
+import java.util.Objects;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
-
-import javax.persistence.*;
-import java.sql.Timestamp;
-import java.util.Objects;
 
 @Entity
 @Getter
@@ -19,11 +24,11 @@ public class ArticleGroup {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ARTICLE_ID", nullable = false)
     private Article article;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "GROUP_ID", nullable = false)
     private Group group;
 

--- a/backend/rush/src/main/java/rush/rush/domain/Comment.java
+++ b/backend/rush/src/main/java/rush/rush/domain/Comment.java
@@ -4,6 +4,7 @@ import com.sun.istack.NotNull;
 import java.sql.Timestamp;
 import java.util.Objects;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -27,11 +28,11 @@ public class Comment {
     @NotNull
     private String content;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false, name = "user_id")
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false, name = "article_id")
     private Article article;
 

--- a/backend/rush/src/main/java/rush/rush/domain/Group.java
+++ b/backend/rush/src/main/java/rush/rush/domain/Group.java
@@ -1,13 +1,21 @@
 package rush.rush.domain;
 
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
-
-import javax.persistence.*;
-import java.sql.Timestamp;
-import java.util.Objects;
 
 @Entity
 @Getter
@@ -29,12 +37,17 @@ public class Group {
     @CreationTimestamp
     private Timestamp createDate;
 
-    public Group(Long id, String name, String invitationCode, Timestamp createDate) {
+    @OneToMany(mappedBy = "group", fetch = FetchType.LAZY)
+    private List<UserGroup> userGroups = new ArrayList<>();
+
+    public Group(Long id, String name, String invitationCode, Timestamp createDate,
+        List<UserGroup> userGroups) {
         validate(name);
         this.id = id;
         this.name = name;
         this.invitationCode = invitationCode;
         this.createDate = createDate;
+        this.userGroups = userGroups;
     }
 
     private void validate(String name) {

--- a/backend/rush/src/main/java/rush/rush/domain/User.java
+++ b/backend/rush/src/main/java/rush/rush/domain/User.java
@@ -2,6 +2,8 @@ package rush.rush.domain;
 
 import com.sun.istack.NotNull;
 import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -9,9 +11,11 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -55,11 +59,13 @@ public class User {
 
     private String providerId;
 
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    private List<UserGroup> userGroups = new ArrayList<>();
+
     public User(Long id, String nickName, String password, String email, String imageUrl,
-        Timestamp joinDate, Timestamp visitDate, AuthProvider provider,
-        String providerId) {
-        validate(id, nickName, password, email, imageUrl, joinDate, visitDate,
-            provider, providerId);
+        Timestamp joinDate, Timestamp visitDate, AuthProvider provider, String providerId,
+        List<UserGroup> userGroups) {
+        validate(id, nickName, password, email, imageUrl, joinDate, visitDate, provider, providerId);
         this.id = id;
         this.nickName = nickName;
         this.password = password;
@@ -69,6 +75,7 @@ public class User {
         this.visitDate = visitDate;
         this.provider = provider;
         this.providerId = providerId;
+        this.userGroups = userGroups;
     }
 
     public void alterImageUrl(String newImageUrl) {

--- a/backend/rush/src/main/java/rush/rush/domain/UserGroup.java
+++ b/backend/rush/src/main/java/rush/rush/domain/UserGroup.java
@@ -1,13 +1,20 @@
 package rush.rush.domain;
 
+import java.sql.Timestamp;
+import java.util.Objects;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
-
-import javax.persistence.*;
-import java.sql.Timestamp;
-import java.util.Objects;
 
 @Entity
 @NoArgsConstructor
@@ -20,11 +27,11 @@ public class UserGroup {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "USER_ID", nullable = false)
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "GROUP_ID", nullable = false)
     private Group group;
 

--- a/backend/rush/src/main/java/rush/rush/dto/SimpleUserResponse.java
+++ b/backend/rush/src/main/java/rush/rush/dto/SimpleUserResponse.java
@@ -1,0 +1,16 @@
+package rush.rush.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Getter
+public class SimpleUserResponse {
+
+    private Long id;
+    private String name;
+    private String imageUrl;
+}

--- a/backend/rush/src/main/java/rush/rush/dto/SimpleUserResponse.java
+++ b/backend/rush/src/main/java/rush/rush/dto/SimpleUserResponse.java
@@ -11,6 +11,6 @@ import lombok.NoArgsConstructor;
 public class SimpleUserResponse {
 
     private Long id;
-    private String name;
+    private String nickname;
     private String imageUrl;
 }

--- a/backend/rush/src/main/java/rush/rush/repository/GroupRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/GroupRepository.java
@@ -14,6 +14,12 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
     @Query("select distinct g from Group g "
         + "inner join g.userGroups usergroup "
         + "inner join usergroup.user user "
+        + "where user.id = :userId and g.id = :groupId")
+    Optional<Group> findByGroupIdAndUserId(@Param("groupId") Long groupId, @Param("userId") Long userId);
+
+    @Query("select distinct g from Group g "
+        + "inner join g.userGroups usergroup "
+        + "inner join usergroup.user user "
         + "where user.id = :userId")
     List<Group> findAllByUserId(@Param("userId") Long userId);
 }

--- a/backend/rush/src/main/java/rush/rush/repository/GroupRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/GroupRepository.java
@@ -1,11 +1,19 @@
 package rush.rush.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import rush.rush.domain.Group;
-
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import rush.rush.domain.Group;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
 
     Optional<Group> findByInvitationCode(String invitationCode);
+
+    @Query("select distinct g from Group g "
+        + "inner join g.userGroups usergroup "
+        + "inner join usergroup.user user "
+        + "where user.id = :userId")
+    List<Group> findAllByUserId(@Param("userId") Long userId);
 }

--- a/backend/rush/src/main/java/rush/rush/repository/UserRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/UserRepository.java
@@ -1,7 +1,10 @@
 package rush.rush.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import rush.rush.domain.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -9,4 +12,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     Boolean existsByEmail(String email);
+
+    @Query("select user from User user "
+        + "inner join user.userGroups usergroups "
+        + "inner join usergroups.group g "
+        + "where g.id = :groupId")
+    List<User> findAllByGroupId(@Param("groupId") Long groupId);
 }

--- a/backend/rush/src/main/java/rush/rush/service/GroupService.java
+++ b/backend/rush/src/main/java/rush/rush/service/GroupService.java
@@ -49,14 +49,11 @@ public class GroupService {
 
     @Transactional
     public List<GroupSummaryResponse> findAllByUser(User user) {
-        List<UserGroup> userGroups = userGroupRepository.findAllByUserId(user.getId());
+        List<Group> groups = groupRepository.findAllByUserId(user.getId());
 
-        return userGroups.stream()
-                .map(userGroup -> {
-                    Group group = userGroup.getGroup();
-                    return new GroupSummaryResponse(group.getId(), group.getName());
-                })
-                .collect(Collectors.toUnmodifiableList());
+        return groups.stream()
+            .map(group -> new GroupSummaryResponse(group.getId(), group.getName()))
+            .collect(Collectors.toUnmodifiableList());
     }
 
     @Transactional

--- a/backend/rush/src/main/java/rush/rush/service/GroupService.java
+++ b/backend/rush/src/main/java/rush/rush/service/GroupService.java
@@ -3,9 +3,9 @@ package rush.rush.service;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import rush.rush.domain.Group;
 import rush.rush.domain.User;
 import rush.rush.domain.UserGroup;
@@ -35,6 +35,7 @@ public class GroupService {
         return savedGroup.getId();
     }
 
+    @Transactional
     public Long join(String invitationCode, User user) {
         Group group = groupRepository.findByInvitationCode(invitationCode)
                 .orElseThrow(() -> new IllegalArgumentException(invitationCode + "는 존재하지 않는 초대코드입니다."));
@@ -46,6 +47,7 @@ public class GroupService {
         return group.getId();
     }
 
+    @Transactional
     public List<GroupSummaryResponse> findAllByUser(User user) {
         List<UserGroup> userGroups = userGroupRepository.findAllByUserId(user.getId());
 
@@ -57,6 +59,7 @@ public class GroupService {
                 .collect(Collectors.toUnmodifiableList());
     }
 
+    @Transactional
     public GroupResponse findOne(Long groupId, User user) {
         UserGroup userGroup = userGroupRepository.findByUserIdAndGroupId(user.getId(), groupId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 그룹이 없거나, "

--- a/backend/rush/src/main/java/rush/rush/service/GroupService.java
+++ b/backend/rush/src/main/java/rush/rush/service/GroupService.java
@@ -12,6 +12,7 @@ import rush.rush.domain.UserGroup;
 import rush.rush.dto.CreateGroupRequest;
 import rush.rush.dto.GroupResponse;
 import rush.rush.dto.GroupSummaryResponse;
+import rush.rush.dto.SimpleUserResponse;
 import rush.rush.repository.GroupRepository;
 import rush.rush.repository.UserGroupRepository;
 import rush.rush.utils.RandomStringGenerator;
@@ -91,5 +92,9 @@ public class GroupService {
                 .user(user)
                 .build();
         userGroupRepository.save(userGroup);
+    }
+
+    public List<SimpleUserResponse> findMembers(Long groupId, User user) {
+        return null;
     }
 }

--- a/backend/rush/src/main/java/rush/rush/service/GroupService.java
+++ b/backend/rush/src/main/java/rush/rush/service/GroupService.java
@@ -59,10 +59,9 @@ public class GroupService {
 
     @Transactional
     public GroupResponse findOne(Long groupId, User user) {
-        UserGroup userGroup = userGroupRepository.findByUserIdAndGroupId(user.getId(), groupId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 그룹이 없거나, "
-                        + "ID=" + user.getId() + " 사용자가 ID=" + groupId + "인 그룹에 접근할 권한이 없습니다."));
-        Group group = userGroup.getGroup();
+        Group group = groupRepository.findByGroupIdAndUserId(groupId, user.getId())
+            .orElseThrow(() -> new IllegalArgumentException("해당 그룹이 없거나, "
+                + "ID=" + user.getId() + " 사용자가 ID=" + groupId + "인 그룹에 접근할 권한이 없습니다."));
         return new GroupResponse(group.getId(), group.getName(), group.getInvitationCode(), group.getCreateDate());
     }
 

--- a/backend/rush/src/test/java/rush/rush/repository/GroupRepositoryTest.java
+++ b/backend/rush/src/test/java/rush/rush/repository/GroupRepositoryTest.java
@@ -50,6 +50,23 @@ class GroupRepositoryTest {
 
     @Test
     @Transactional
+    void findByGroupIdAndUserId() {
+        // given
+        User user = persistUser(testEntityManager, "test@seoultech.com");
+        Group group = persistGroup(testEntityManager);
+        persistUserGroup(testEntityManager, user, group);
+
+        // when
+        Optional<Group> result = groupRepository
+            .findByGroupIdAndUserId(group.getId(), user.getId());
+
+        // then
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.get().getId()).isEqualTo(group.getId());
+    }
+
+    @Test
+    @Transactional
     void findAllByUserId() {
         // given
         User user1 = persistUser(testEntityManager, "test@seoultech.com");

--- a/backend/rush/src/test/java/rush/rush/repository/GroupRepositoryTest.java
+++ b/backend/rush/src/test/java/rush/rush/repository/GroupRepositoryTest.java
@@ -2,7 +2,10 @@ package rush.rush.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static rush.rush.repository.SetUpMethods.persistGroup;
+import static rush.rush.repository.SetUpMethods.persistUser;
+import static rush.rush.repository.SetUpMethods.persistUserGroup;
 
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,6 +15,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 import rush.rush.domain.Group;
+import rush.rush.domain.User;
 
 @ExtendWith(SpringExtension.class)  // junit5에게 Spring support를 enable 하라고 말하는거
 @DataJpaTest
@@ -42,5 +46,22 @@ class GroupRepositoryTest {
         assertThat(resultGroup.getInvitationCode()).isNotNull();
         assertThat(resultGroup.getInvitationCode()).isEqualTo(group.getInvitationCode());
         assertThat(resultGroup.getCreateDate()).isEqualTo(group.getCreateDate());
+    }
+
+    @Test
+    @Transactional
+    void findAllByUserId() {
+        // given
+        User user1 = persistUser(testEntityManager, "test@seoultech.com");
+        Group group1 = persistGroup(testEntityManager);
+        Group group2 = persistGroup(testEntityManager);
+        persistUserGroup(testEntityManager, user1, group1);
+        persistUserGroup(testEntityManager, user1, group2);
+
+        // when
+        List<Group> groups = groupRepository.findAllByUserId(user1.getId());
+
+        // then
+        assertThat(groups.size()).isEqualTo(2);
     }
 }

--- a/backend/rush/src/test/java/rush/rush/repository/UserRepositoryTest.java
+++ b/backend/rush/src/test/java/rush/rush/repository/UserRepositoryTest.java
@@ -1,0 +1,48 @@
+package rush.rush.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static rush.rush.repository.SetUpMethods.persistGroup;
+import static rush.rush.repository.SetUpMethods.persistUser;
+import static rush.rush.repository.SetUpMethods.persistUserGroup;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+import rush.rush.domain.Group;
+import rush.rush.domain.User;
+
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+
+    @Test
+    @Transactional
+    void findAllByGroupId() {
+        // given
+        User user1 = persistUser(testEntityManager, "test1@naver.com");
+        User user2 = persistUser(testEntityManager, "test2@naver.com");
+        User user3 = persistUser(testEntityManager, "test3@naver.com");
+        Group group1 = persistGroup(testEntityManager);
+        Group group2 = persistGroup(testEntityManager);
+        persistUserGroup(testEntityManager, user1, group1);
+        persistUserGroup(testEntityManager, user2, group1);
+        persistUserGroup(testEntityManager, user3, group2);
+
+        // when
+        List<User> group1Members = userRepository.findAllByGroupId(group1.getId());
+
+        // then
+        assertThat(group1Members.size()).isEqualTo(2);
+    }
+}

--- a/frontend/rush/src/api/CreateCommentApi.js
+++ b/frontend/rush/src/api/CreateCommentApi.js
@@ -20,7 +20,7 @@ const createCommentApi = (content, articleId, accessToken, history) => {
       if (error.response.status === 401 || error.response.status === 403) {
         alert("로그인이 만료되었습니다. 다시 로그인해주세요.");
         history.push("/login");
-        return true;
+        return Promise.reject();
       }
       alert("이유가 뭔지 모르겠지만 댓글작성 실패했음.");
     });

--- a/frontend/rush/src/api/CreateGroupApi.js
+++ b/frontend/rush/src/api/CreateGroupApi.js
@@ -29,7 +29,7 @@ const createGroupApi = ({groupName, history}) => {
     if (error.response.status === 401 || error.response.status === 403) {
       alert("로그인이 만료되었습니다. 다시 로그인해주세요.");
       history.push("/login");
-      return;
+      return Promise.reject();
     }
     alert("그룹 가입 실패");
   });

--- a/frontend/rush/src/api/FindGroupApi.js
+++ b/frontend/rush/src/api/FindGroupApi.js
@@ -22,7 +22,7 @@ const findGroupApi = ({ groupId, accessToken, history }) => {
     if (error.response.status === 401 || error.response.status === 403) {
       alert("로그인이 만료되었습니다. 다시 로그인해주세요.");
       history.push("/login");
-      return;
+      return Promise.reject();
     }
     alert("이유가 뭔지 모르겠지만 내 그룹을 불러오는데 실패했음...");
   });

--- a/frontend/rush/src/api/FindGroupMembersApi.js
+++ b/frontend/rush/src/api/FindGroupMembersApi.js
@@ -1,0 +1,31 @@
+import axios from "axios";
+import {BACKEND_ADDRESS} from "../constants/ADDRESS";
+
+const findGroupMembersApi = ({ groupId, accessToken, history }) => {
+  if (!accessToken) {
+    alert("로그인이 필요한 서비스입니다.")
+    history.push('/login');
+    return Promise.reject("토큰이 없음");
+  }
+  const config = {
+    headers: {
+      Authorization: "Bearer " + accessToken
+    }
+  }
+  return axios.get(BACKEND_ADDRESS + "/groups/" + groupId + "/members", config)
+  .then(response => {
+    if (response.status === 200) {
+      return response.data
+    }
+  })
+  .catch(error => {
+    if (error.response.status === 401 || error.response.status === 403) {
+      alert("로그인이 만료되었습니다. 다시 로그인해주세요.");
+      history.push("/login");
+      return;
+    }
+    alert("이유가 뭔지 모르겠지만 그룹원 목록을 불러오는데 실패했음...");
+  });
+};
+
+export default findGroupMembersApi;

--- a/frontend/rush/src/api/FindGroupMembersApi.js
+++ b/frontend/rush/src/api/FindGroupMembersApi.js
@@ -22,7 +22,7 @@ const findGroupMembersApi = ({ groupId, accessToken, history }) => {
     if (error.response.status === 401 || error.response.status === 403) {
       alert("로그인이 만료되었습니다. 다시 로그인해주세요.");
       history.push("/login");
-      return;
+      return Promise.reject();
     }
     alert("이유가 뭔지 모르겠지만 그룹원 목록을 불러오는데 실패했음...");
   });

--- a/frontend/rush/src/api/FindMapArticlesApi.js
+++ b/frontend/rush/src/api/FindMapArticlesApi.js
@@ -35,7 +35,7 @@ export const findPrivateMapArticles = (latitude, latitudeRange, longitude, longi
     if (error.response.status === 401 || error.response.status === 403) {
       alert("로그인이 만료되었습니다. 다시 로그인해주세요.");
       history.push("/login");
-      return;
+      return Promise.reject();
     }
     alert("이유가 뭔지 모르겠지만 개인지도 글 가져오기에 실패했음...");
   });

--- a/frontend/rush/src/api/FindMyGroupsApi.js
+++ b/frontend/rush/src/api/FindMyGroupsApi.js
@@ -25,7 +25,7 @@ const findMyGroupsApi = (history) => {
     if (error.response.status === 401 || error.response.status === 403) {
       alert("로그인이 만료되었습니다. 다시 로그인해주세요.");
       history.push("/login");
-      return;
+      return Promise.reject();
     }
     alert("이유가 뭔지 모르겠지만 내 그룹을 불러오는데 실패했음...");
   });

--- a/frontend/rush/src/api/FindWritingApi.js
+++ b/frontend/rush/src/api/FindWritingApi.js
@@ -21,7 +21,7 @@ const findWritingApi = (articleId, mapType, history) => {
       if (error.response.status === 401 || error.response.status === 403) {
         alert("로그인이 만료되었습니다. 다시 로그인해주세요.");
         history.push("/login");
-        return;
+        return Promise.reject();
       }
       alert("이유가 뭔지 모르겠지만 개인지도 글 가져오기에 실패했음...");
     });

--- a/frontend/rush/src/api/JoinGroupApi.js
+++ b/frontend/rush/src/api/JoinGroupApi.js
@@ -26,7 +26,7 @@ const joinGroupApi = ({invitationCode, history}) => {
     if (error.response.status === 401 || error.response.status === 403) {
       alert("로그인이 만료되었습니다. 다시 로그인해주세요.");
       history.push("/login");
-      return;
+      return Promise.reject();
     }
     alert("이유가 뭔지 모르겠지만 그룹 가입에 실패했음...");
   });

--- a/frontend/rush/src/components/group/GroupName.js
+++ b/frontend/rush/src/components/group/GroupName.js
@@ -7,7 +7,7 @@ const NameStyle = styled.div`
   margin-bottom: 15px;
 `;
 
-const Name = (props) => {
+const GroupName = (props) => {
   return (
     <NameStyle>
       {props.children}
@@ -15,4 +15,4 @@ const Name = (props) => {
   );
 };
 
-export default Name;
+export default GroupName;

--- a/frontend/rush/src/components/group/GroupPage.js
+++ b/frontend/rush/src/components/group/GroupPage.js
@@ -33,7 +33,6 @@ const GroupPage = (props) => {
       accessToken: accessToken,
       history: props.history
     }).then(groupMembersPromise => {
-      console.log(groupMembersPromise)
       setGroupMembers(groupMembersPromise)
     });
   }, [groupId, accessToken]);

--- a/frontend/rush/src/components/group/GroupPage.js
+++ b/frontend/rush/src/components/group/GroupPage.js
@@ -4,9 +4,11 @@ import {DisplayBox, Outside} from "../common/Box";
 import {ACCESS_TOKEN} from "../../constants/SessionStorage";
 import findGroupApi from "../../api/FindGroupApi";
 import {withRouter} from "react-router-dom";
-import Name from "./Name";
+import GroupName from "./GroupName";
 import CancelButton from "./CancelButton";
 import InvitationCode from "./InvitationCode";
+import findGroupMembersApi from "../../api/FindGroupMembersApi";
+import GroupMembers from "./members/GroupMembers";
 
 const GroupPage = (props) => {
   const accessToken = sessionStorage.getItem(ACCESS_TOKEN);
@@ -17,20 +19,33 @@ const GroupPage = (props) => {
     name: "",
     invitationCode: ""
   });
+  const [groupMembers, setGroupMembers] = useState([]);
+
   useEffect(() => {
     findGroupApi({
       groupId: groupId,
       accessToken: accessToken,
       history: props.history
     }).then(groupPromise => setGroup(groupPromise));
+
+    findGroupMembersApi({
+      groupId: groupId,
+      accessToken: accessToken,
+      history: props.history
+    }).then(groupMembersPromise => {
+      console.log(groupMembersPromise)
+      setGroupMembers(groupMembersPromise)
+    });
   }, [groupId, accessToken]);
 
   return (
     <Outside>
       <DisplayBox style={{height: WindowSize().height - 50, marginTop: 15}}>
         <CancelButton/>
-        <Name>{group.name}</Name>
+        <GroupName>{group.name}</GroupName>
         <InvitationCode invitationCode={group.invitationCode}/>
+        <hr style={{margin: "20px 0 8px 0"}}/>
+        <GroupMembers members={groupMembers}/>
       </DisplayBox>
     </Outside>
   );

--- a/frontend/rush/src/components/group/InvitationCode.js
+++ b/frontend/rush/src/components/group/InvitationCode.js
@@ -21,7 +21,6 @@ const InvitationCode = ({invitationCode}) => {
   const onCopyButtonClicked = (e) => {
     e.preventDefault();
     const tempInput = tempTextInput.current;
-    console.log(tempInput)
     tempInput.select();
     document.execCommand("copy");
     alert("초대코드가 복사되었습니다! 초대할 상대에게 공유해주세요!");

--- a/frontend/rush/src/components/group/InvitationCode.js
+++ b/frontend/rush/src/components/group/InvitationCode.js
@@ -1,27 +1,58 @@
-import React from 'react';
+import React, {useRef} from 'react';
 import styled from "styled-components";
 
 const InvitationCodeStyle = styled.div`
+  display: flex;
+  flex-direction: column;
   padding: 0 15px;
   font-size: 18px;
 `;
 
 const CopyButton = styled.button`
   margin: 0 12px;
-  padding: 0 20px;
+  padding: 4px 30px;
   font-size: 18px;
   border-radius: 20px;
 `;
 
 const InvitationCode = ({invitationCode}) => {
+  const tempTextInput = useRef();
+
   const onCopyButtonClicked = (e) => {
     e.preventDefault();
-    alert("아직 개발중입니다!");
+    const tempInput = tempTextInput.current;
+    console.log(tempInput)
+    tempInput.select();
+    document.execCommand("copy");
+    alert("초대코드가 복사되었습니다! 초대할 상대에게 공유해주세요!");
   }
   return (
     <InvitationCodeStyle>
-      {"초대코드 : " + invitationCode}
-      <CopyButton onClick={onCopyButtonClicked}>복사</CopyButton>
+      <div style={{
+        flexDirection: "row",
+        margin: "5px"
+      }}>
+        초대코드
+        <CopyButton onClick={onCopyButtonClicked}>복사</CopyButton>
+      </div>
+      <input
+        type="text"
+        ref={tempTextInput}
+        style={{
+          background: "skyblue",
+          padding: "8px",
+          textAlign: "center",
+          borderRadius: "20px",
+          marginTop: "5px",
+          borderWidth: 0,
+          fontSize: "18px",
+          marginLeft: "5px",
+          overflow: "hidden",
+          outline: "none"
+        }}
+        value={invitationCode}
+        readOnly
+      />
     </InvitationCodeStyle>
   );
 };

--- a/frontend/rush/src/components/group/members/GroupMembers.js
+++ b/frontend/rush/src/components/group/members/GroupMembers.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import Member from "./Member";
+
+const GroupMembers = ({members}) => {
+  return (
+    <>
+      {
+        members.map(member => <Member
+          userId={member.id}
+          nickname={member.nickname}
+          userImageUrl={member.imageUrl}
+        />)
+      }
+    </>
+  );
+};
+
+export default GroupMembers;

--- a/frontend/rush/src/components/group/members/Member.js
+++ b/frontend/rush/src/components/group/members/Member.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import Profile from "./Profile";
+import Nickname from "./NickName";
+
+const Member = ({userId, nickname, userImageUrl}) => {
+  return (
+    <div style={{
+      display: "flex",
+      flexDirection: "row",
+      alignItems: "center"
+    }}>
+      <Profile userImageUrl={userImageUrl}/>
+      <Nickname nickname={nickname}/>
+    </div>
+  );
+};
+
+export default Member;

--- a/frontend/rush/src/components/group/members/NickName.js
+++ b/frontend/rush/src/components/group/members/NickName.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const NickName = ({nickname}) => {
+  return (
+    <div style={{ fontSize: "120%"}}>
+      {nickname}
+    </div>
+  );
+};
+
+export default NickName;

--- a/frontend/rush/src/components/group/members/Profile.js
+++ b/frontend/rush/src/components/group/members/Profile.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import styled from "styled-components";
+
+const ProfileStyle = styled.div`
+  display: inline-block;
+  margin: 10px 18px;
+  width: 50px;
+  height: 50px;
+  background-image: url("${props => props.userImageUrl}");
+  background-size: contain;
+  border-radius: 100px;
+  border: 2px solid black;
+`;
+
+const Profile = ({userImageUrl}) => {
+  return(
+    <ProfileStyle
+      userImageUrl={userImageUrl}
+    />
+  );
+};
+
+export default Profile;

--- a/frontend/rush/src/components/myPage/MyPage.js
+++ b/frontend/rush/src/components/myPage/MyPage.js
@@ -24,6 +24,7 @@ const MyPage = (props) => {
     if (!accessToken) {
       alert("로그인이 만료되었습니다. 다시 로그인해주세요.");
       props.history.push("/login");
+      return;
     }
     findMyGroupsApi(accessToken).then(groupsPromise=>{
       setMyGroups(groupsPromise)


### PR DESCRIPTION
**이슈 번호**

resolved: #105 

**작업 내용**

1. 그룹페이지 팀원목록 조회기능 구현 (프론트 & 백엔드)
2. 초대코드 복사기능 구현 (프론트)
3. GroupService SQL 최적화 (백엔드)
![image](https://user-images.githubusercontent.com/28949340/126310481-87229449-69cc-43fe-8c08-92fd010ccdab.png)


**테스트 작성 여부**

- [ ] Test case

**주의 사항**