### PR TITLE
refactor: 마이페이지 게시글 가져오기 최적화

### DIFF
--- a/backend/rush/src/main/java/rush/rush/repository/ArticleRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/ArticleRepository.java
@@ -31,8 +31,8 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
         @Param("userId") Long userId);
 
     @Query("select distinct article from Article article "
-        + "join fetch article.articleGroups articlegroups "
-        + "join fetch articlegroups.group "
+        + "left join fetch article.articleGroups articlegroups "
+        + "left join fetch articlegroups.group "
         + "where article.user.id = :userId "
         + "order by article.createDate desc")
     List<Article> findArticlesWithGroupsByUserId(@Param("userId") Long userId);

--- a/backend/rush/src/main/java/rush/rush/repository/ArticleRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/ArticleRepository.java
@@ -29,4 +29,11 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
         + "where article.id = :articleId and groupmember.id = :userId")
     Optional<Article> findAsGroupMapArticle(@Param("articleId") Long articleId,
         @Param("userId") Long userId);
+
+    @Query("select distinct article from Article article "
+        + "join fetch article.articleGroups articlegroups "
+        + "join fetch articlegroups.group "
+        + "where article.user.id = :userId "
+        + "order by article.createDate desc")
+    List<Article> findArticlesWithGroupsByUserId(@Param("userId") Long userId);
 }

--- a/backend/rush/src/main/java/rush/rush/service/FindCommentService.java
+++ b/backend/rush/src/main/java/rush/rush/service/FindCommentService.java
@@ -9,7 +9,6 @@ import rush.rush.domain.Comment;
 import rush.rush.domain.User;
 import rush.rush.dto.AuthorResponse;
 import rush.rush.dto.CommentResponse;
-import rush.rush.repository.ArticleRepository;
 import rush.rush.repository.CommentRepository;
 
 @Service
@@ -17,7 +16,6 @@ import rush.rush.repository.CommentRepository;
 public class FindCommentService {
 
     private final CommentRepository commentRepository;
-    private final ArticleRepository articleRepository;
 
     @Transactional
     public List<CommentResponse> findCommentsOfPublicArticle(Long articleId) {

--- a/backend/rush/src/main/java/rush/rush/service/FindMyArticlesService.java
+++ b/backend/rush/src/main/java/rush/rush/service/FindMyArticlesService.java
@@ -6,11 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import rush.rush.domain.Article;
-import rush.rush.domain.ArticleGroup;
-import rush.rush.domain.Group;
 import rush.rush.dto.GroupSummaryResponse;
 import rush.rush.dto.MyPageArticleResponse;
-import rush.rush.repository.ArticleGroupRepository;
 import rush.rush.repository.ArticleRepository;
 
 @Service
@@ -18,36 +15,28 @@ import rush.rush.repository.ArticleRepository;
 public class FindMyArticlesService {
 
     final private ArticleRepository articleRepository;
-    final private ArticleGroupRepository articleGroupRepository;
-    
+
     @Transactional
     public List<MyPageArticleResponse> findMyArticles(Long userId) {
-
-        List<Article> articles = articleRepository.findAllByUserId(userId);
+        List<Article> articles = articleRepository.findArticlesWithGroupsByUserId(userId);
 
         return articles.stream()
-            .map(article ->{
-                List<GroupSummaryResponse> groups = findAllByArticle(article);
-                return new MyPageArticleResponse(
-                    article.getId(),
-                    article.getTitle(),
-                    article.isPublicMap(),
-                    article.isPrivateMap(),
-                    groups);
-            })
+            .map(article -> new MyPageArticleResponse(
+                article.getId(),
+                article.getTitle(),
+                article.isPublicMap(),
+                article.isPrivateMap(),
+                findAllByArticle(article)
+            ))
             .collect(Collectors.toUnmodifiableList());
     }
 
-    @Transactional
-    public List<GroupSummaryResponse> findAllByArticle(Article article) {
-
-        List<ArticleGroup> articleGroups = articleGroupRepository.findAllByArticleId(article.getId());
-
-        return articleGroups.stream()
-            .map(articleGroup -> {
-                Group group = articleGroup.getGroup();
-                return new GroupSummaryResponse(group.getId(), group.getName());
-            })
-            .collect(Collectors.toUnmodifiableList());
+    private List<GroupSummaryResponse> findAllByArticle(Article article) {
+        return article.getArticleGroups().stream()
+            .map((articleGroup) -> new GroupSummaryResponse(
+                articleGroup.getGroup().getId(),
+                articleGroup.getGroup().getName()
+            ))
+            .collect(Collectors.toList());
     }
 }

--- a/backend/rush/src/test/java/rush/rush/repository/ArticleRepositoryTest.java
+++ b/backend/rush/src/test/java/rush/rush/repository/ArticleRepositoryTest.java
@@ -9,6 +9,7 @@ import static rush.rush.repository.SetUpMethods.persistUserGroup;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +18,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 import rush.rush.domain.Article;
+import rush.rush.domain.ArticleGroup;
 import rush.rush.domain.Group;
 import rush.rush.domain.User;
 
@@ -156,5 +158,48 @@ class ArticleRepositoryTest {
             article.getId(), anotherGroupUser.getId());
         // then
         assertThat(foundArticle2.isPresent()).isFalse();
+    }
+
+    @Test
+    @Transactional
+    void findArticlesWithGroupsByUserId(){
+        //given
+        User user = persistUser(testEntityManager, "test@email.com");
+
+        Group group1 = persistGroup(testEntityManager);
+        Group group2 = persistGroup(testEntityManager);
+        Group group3 = persistGroup(testEntityManager);
+
+        persistUserGroup(testEntityManager, user, group1);
+        persistUserGroup(testEntityManager, user, group2);
+
+        Article article1 = persistArticle(testEntityManager, user, true, true, 37.63, 127.07);
+        Article article2 = persistArticle(testEntityManager, user, true, true, 37.63, 127.07);
+
+        persistArticleGroup(testEntityManager, article1, group1);
+        persistArticleGroup(testEntityManager, article1, group2);
+        persistArticleGroup(testEntityManager, article2, group3);
+
+        testEntityManager.flush();
+        testEntityManager.clear();
+
+        // when
+        List<Article> articles = articleRepository.findArticlesWithGroupsByUserId(user.getId());
+
+        //then
+        List<Group> groups2 = articles.get(0)
+            .getArticleGroups()
+            .stream()
+            .map(ArticleGroup::getGroup)
+            .collect(Collectors.toList());
+
+        List<Group> groups1 = articles.get(1)
+            .getArticleGroups()
+            .stream()
+            .map(ArticleGroup::getGroup)
+            .collect(Collectors.toList());
+
+        assertThat(groups2.size()).isEqualTo(1);
+        assertThat(groups1.size()).isEqualTo(2);
     }
 }

--- a/backend/rush/src/test/java/rush/rush/repository/ArticleRepositoryTest.java
+++ b/backend/rush/src/test/java/rush/rush/repository/ArticleRepositoryTest.java
@@ -170,15 +170,14 @@ class ArticleRepositoryTest {
         Group group2 = persistGroup(testEntityManager);
         Group group3 = persistGroup(testEntityManager);
 
-        persistUserGroup(testEntityManager, user, group1);
-        persistUserGroup(testEntityManager, user, group2);
-
         Article article1 = persistArticle(testEntityManager, user, true, true, 37.63, 127.07);
         Article article2 = persistArticle(testEntityManager, user, true, true, 37.63, 127.07);
+        Article article3 = persistArticle(testEntityManager, user, true, true, 37.63, 127.07);
+        Article article4 = persistArticle(testEntityManager, user, true, true, 37.63, 127.07);
 
-        persistArticleGroup(testEntityManager, article1, group1);
-        persistArticleGroup(testEntityManager, article1, group2);
-        persistArticleGroup(testEntityManager, article2, group3);
+        persistArticleGroup(testEntityManager, article3, group1);
+        persistArticleGroup(testEntityManager, article3, group2);
+        persistArticleGroup(testEntityManager, article4, group3);
 
         testEntityManager.flush();
         testEntityManager.clear();
@@ -199,6 +198,7 @@ class ArticleRepositoryTest {
             .map(ArticleGroup::getGroup)
             .collect(Collectors.toList());
 
+        assertThat(articles.size()).isEqualTo(4);
         assertThat(groups2.size()).isEqualTo(1);
         assertThat(groups1.size()).isEqualTo(2);
     }


### PR DESCRIPTION
**이슈 번호**

resolved: #114

**작업 내용**

1. 마이페이지에서 그룹을 포한한 게시글을 가져오는 과정에서 DB조회를 줄임으로서 성능 향상

**테스트 작성 여부**

- [X] Test case

**주의 사항**
목요일날 같이 봤던 ArticleRepository에 findArticlesWithGroupsByUserId 에서 join fetch로 하면 inner join이 발생하여 Article 에서 articleGroups가 비어있는 Article 은 가져오지 않는 문제가 발생함.(즉, 그룹이 없는 게시글을 가져오지 않음)
그래서 left join fetch 로 left outer join 으로 가져오게 수정함. 