### PR TITLE
feat: 게시글 좋아요 권한 설정 및 프론트 일부 오류 개선

### DIFF
--- a/backend/rush/src/main/java/rush/rush/controller/ArticleLikeController.java
+++ b/backend/rush/src/main/java/rush/rush/controller/ArticleLikeController.java
@@ -9,31 +9,36 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import rush.rush.domain.MapType;
 import rush.rush.security.CurrentUser;
 import rush.rush.security.user.UserPrincipal;
 import rush.rush.service.ArticleLikeService;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/articles/{id}/like")
+@RequestMapping("/articles/{mapType}/{articleId}/like")
 public class ArticleLikeController {
 
     private final ArticleLikeService articleLikeService;
 
     @PostMapping
-    public ResponseEntity<Void> changeMyLike(@PathVariable Long id,
+    public ResponseEntity<Void> changeMyLike(
+        @PathVariable Long articleId,
+        @PathVariable("mapType") String mapType,
         @RequestParam(value = "hasiliked") Boolean hasILiked,
         @CurrentUser UserPrincipal userPrincipal){
-        articleLikeService.changeMyLike(id,hasILiked, userPrincipal.getUser());
+        articleLikeService.changeMyLike(articleId, MapType.from(mapType), hasILiked, userPrincipal.getUser());
 
         return ResponseEntity.status(HttpStatus.CREATED)
             .build();
     }
 
     @GetMapping
-    public ResponseEntity<Boolean> checkMyLike(@PathVariable Long id,
+    public ResponseEntity<Boolean> checkMyLike(
+        @PathVariable Long articleId,
+        @PathVariable("mapType") String mapType,
         @CurrentUser UserPrincipal userPrincipal){
-        boolean result= articleLikeService.hasILiked(id, userPrincipal.getId());
+        boolean result= articleLikeService.hasILiked(articleId, MapType.from(mapType), userPrincipal.getId());
 
         return ResponseEntity.ok()
             .body(result);

--- a/backend/rush/src/main/java/rush/rush/dto/ArticleResponse.java
+++ b/backend/rush/src/main/java/rush/rush/dto/ArticleResponse.java
@@ -18,5 +18,5 @@ public class ArticleResponse {
     private Double longitude;
     private AuthorResponse author;
     private Timestamp createDate;
-    private int totalLikes;
+    private Long totalLikes;
 }

--- a/backend/rush/src/main/java/rush/rush/repository/ArticleLikeRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/ArticleLikeRepository.java
@@ -11,5 +11,4 @@ public interface ArticleLikeRepository extends JpaRepository<ArticleLike,Long> {
     Integer countByArticleId(Long articleId);
 
     Integer countByUserIdAndArticleId(Long userId, Long ArticleId);
-
 }

--- a/backend/rush/src/main/java/rush/rush/repository/ArticleLikeRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/ArticleLikeRepository.java
@@ -2,13 +2,39 @@ package rush.rush.repository;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import rush.rush.domain.ArticleLike;
 
 public interface ArticleLikeRepository extends JpaRepository<ArticleLike,Long> {
 
     Optional<ArticleLike> findByUserIdAndArticleId(Long userId, Long articleId);
 
-    Integer countByArticleId(Long articleId);
+    Long countByArticleId(Long articleId);
 
-    Integer countByUserIdAndArticleId(Long userId, Long ArticleId);
+    @Query("select count(articlelike) from ArticleLike articlelike "
+        + "where articlelike.article.id = :articleId "
+        + "and articlelike.article.publicMap = true "
+        + "and articlelike.user.id = :userId ")
+    Long countOfPublicArticle(
+        @Param("articleId") Long articleId, @Param("userId") Long userId);
+
+    @Query("select count(articlelike) from ArticleLike articlelike "
+        + "where articlelike.article.id = :articleId "
+        + "and articlelike.article.user.id = :userId "
+        + "and articlelike.user.id = :userId ")
+    Long countOfPrivateArticle(
+        @Param("articleId") Long articleId, @Param("userId") Long userId);
+
+    @Query("select count(articlelike) from ArticleLike articlelike "
+        + "inner join articlelike.article article "
+        + "inner join article.articleGroups articlegroup "
+        + "inner join articlegroup.group g "
+        + "inner join g.userGroups usergroup "
+        + "inner join usergroup.user user "
+        + "where article.id = :articleId "
+        + "and user.id = :userId "
+        + "and articlelike.user.id = :userId ")
+    Long countOfGroupedArticle(
+        @Param("articleId") Long articleId, @Param("userId") Long userId);
 }

--- a/backend/rush/src/main/java/rush/rush/service/ArticleLikeService.java
+++ b/backend/rush/src/main/java/rush/rush/service/ArticleLikeService.java
@@ -32,9 +32,16 @@ public class ArticleLikeService {
 
     @Transactional
     public boolean hasILiked(Long articleId, MapType mapType, Long userId) {
-        int count = articleLikeRepository.countByUserIdAndArticleId(userId,articleId);
-
-        return count >= 1;
+        if (mapType == MapType.PUBLIC) {
+            return articleLikeRepository.countOfPublicArticle(articleId, userId) >=1;
+        }
+        if (mapType == MapType.PRIVATE) {
+            return articleLikeRepository.countOfPrivateArticle(articleId, userId) >=1;
+        }
+        if (mapType == MapType.GROUPED) {
+            return articleLikeRepository.countOfGroupedArticle(articleId, userId) >=1;
+        }
+        throw new IllegalStateException("MapType 오류 - " + mapType.name());
     }
 
     private void changeMyLikeOnPublicArticle(Long articleId, Boolean hasILiked, User user){
@@ -68,7 +75,6 @@ public class ArticleLikeService {
                 .article(article)
                 .build());
         }
-
     }
 
     private ArticleLike findLike(Long articleId, Long userId){

--- a/backend/rush/src/main/java/rush/rush/service/ArticleLikeService.java
+++ b/backend/rush/src/main/java/rush/rush/service/ArticleLikeService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import rush.rush.domain.Article;
 import rush.rush.domain.ArticleLike;
+import rush.rush.domain.MapType;
 import rush.rush.domain.User;
 import rush.rush.repository.ArticleLikeRepository;
 import rush.rush.repository.ArticleRepository;
@@ -17,34 +18,61 @@ public class ArticleLikeService {
     private final ArticleRepository articleRepository;
 
     @Transactional
-    public void changeMyLike(Long articleId, Boolean hasILiked, User user) {
-        if(hasILiked){
-            articleLikeRepository.delete(findLike(articleId,user.getId()));
+    public void changeMyLike(Long articleId, MapType mapType, Boolean hasILiked, User user) {
+        if (mapType == MapType.PUBLIC) {
+            changeMyLikeOnPublicArticle(articleId, hasILiked, user);
         }
-        else{
-            Article article = findArticle(articleId);
-            articleLikeRepository.save(ArticleLike.builder()
-                .user(user)
-                .article(article)
-                .build());
+        else if (mapType == MapType.PRIVATE) {
+            changeMyLikeOnPrivateArticle(articleId, hasILiked, user);
+        }
+        else if (mapType == MapType.GROUPED) {
+            changeMyLikeOnGroupedArticle(articleId, hasILiked, user);
         }
     }
 
     @Transactional
-    public boolean hasILiked(Long articleId, Long userId) {
+    public boolean hasILiked(Long articleId, MapType mapType, Long userId) {
         int count = articleLikeRepository.countByUserIdAndArticleId(userId,articleId);
 
         return count >= 1;
     }
 
-    private Article findArticle(Long articleId){
-        return articleRepository.findById(articleId)
-            .orElseThrow(() -> new IllegalArgumentException("해당하는 게시글이 없습니다"));
+    private void changeMyLikeOnPublicArticle(Long articleId, Boolean hasILiked, User user){
+        Article article = articleRepository.findByPublicMapTrueAndId(articleId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 article ID 입니다."));
+
+        changeLike(article, user, hasILiked);
+    }
+
+    private void changeMyLikeOnPrivateArticle(Long articleId, Boolean hasILiked, User user){
+        Article article = articleRepository.findByPrivateMapTrueAndIdAndUserId(articleId, user.getId())
+            .orElseThrow(() -> new IllegalArgumentException("해당 article 조회 권한이 없거나, 존재하지 않는 article ID 입니다."));
+
+        changeLike(article, user, hasILiked);
+    }
+
+    private void changeMyLikeOnGroupedArticle(Long articleId, Boolean hasILiked, User user){
+        Article article = articleRepository.findAsGroupMapArticle(articleId, user.getId())
+            .orElseThrow(() -> new IllegalArgumentException("해당 article 조회 권한이 없거나, 존재하지 않는 article ID 입니다."));
+
+        changeLike(article, user, hasILiked);
+    }
+
+    private void changeLike(Article article, User user, Boolean hasILiked){
+        if(hasILiked){
+            articleLikeRepository.delete(findLike(article.getId(), user.getId()));
+        }
+        else{
+            articleLikeRepository.save(ArticleLike.builder()
+                .user(user)
+                .article(article)
+                .build());
+        }
+
     }
 
     private ArticleLike findLike(Long articleId, Long userId){
         return  articleLikeRepository.findByUserIdAndArticleId(userId, articleId)
             .orElseThrow(() -> new IllegalArgumentException("해당하는 좋아요는 없습니다"));
     }
-
 }

--- a/backend/rush/src/main/java/rush/rush/service/FindArticleService.java
+++ b/backend/rush/src/main/java/rush/rush/service/FindArticleService.java
@@ -61,7 +61,7 @@ public class FindArticleService {
         User author = article.getUser();
         AuthorResponse authorResponse = new AuthorResponse(author.getId(),
             author.getNickName(), author.getImageUrl());
-        int totalLikes = articleLikeRepository.countByArticleId(article.getId());
+        Long totalLikes = articleLikeRepository.countByArticleId(article.getId());
 
         return new ArticleResponse(
             article.getId(),

--- a/backend/rush/src/test/java/rush/rush/repository/ArticleLikeRepositoryTest.java
+++ b/backend/rush/src/test/java/rush/rush/repository/ArticleLikeRepositoryTest.java
@@ -1,9 +1,12 @@
 package rush.rush.repository;
 
-import static rush.rush.repository.SetUpMethods.persistArticle;
-import static rush.rush.repository.SetUpMethods.persistUser;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static rush.rush.repository.SetUpMethods.persistArticle;
+import static rush.rush.repository.SetUpMethods.persistArticleGroup;
+import static rush.rush.repository.SetUpMethods.persistGroup;
+import static rush.rush.repository.SetUpMethods.persistUser;
+import static rush.rush.repository.SetUpMethods.persistUserGroup;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,6 +17,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 import rush.rush.domain.Article;
 import rush.rush.domain.ArticleLike;
+import rush.rush.domain.Group;
 import rush.rush.domain.User;
 
 @ExtendWith(SpringExtension.class)  // junit5에게 Spring support를 enable 하라고 말하는거
@@ -28,17 +32,19 @@ class ArticleLikeRepositoryTest {
 
     User savedUser1;
     User savedUser2;
-    Article savedArticle1;
-    Article savedArticle2;
+    Article articleOnPrivateMap;
+    Article articleOnPublicMap;
 
     @BeforeEach
     void setUp(){
         savedUser1 = persistUser(testEntityManager, "test@email.com");
         savedUser2 = persistUser(testEntityManager, "test2@email.com");
-        savedArticle1 = persistArticle(testEntityManager, savedUser1, false, true, 0.0, 0.0);
-        savedArticle2 = persistArticle(testEntityManager, savedUser1, false, true, 0.0, 0.0);
-        persistArticleLike(savedUser1, savedArticle1);
-        persistArticleLike(savedUser2, savedArticle1);
+        articleOnPrivateMap = persistArticle(testEntityManager, savedUser1, false, true, 0.0, 0.0);
+        articleOnPublicMap = persistArticle(testEntityManager, savedUser1, true, false, 0.0, 0.0);
+        persistArticleLike(savedUser1, articleOnPublicMap);
+        persistArticleLike(savedUser2, articleOnPublicMap);
+        persistArticleLike(savedUser1, articleOnPrivateMap);
+        persistArticleLike(savedUser2, articleOnPrivateMap);
     }
 
     @Test
@@ -47,13 +53,14 @@ class ArticleLikeRepositoryTest {
         //given
 
         //when
-        ArticleLike articleLikeTest = articleLikeRepository.findByUserIdAndArticleId(savedUser1.getId(),savedArticle1.getId())
+        ArticleLike articleLikeTest = articleLikeRepository.findByUserIdAndArticleId(savedUser1.getId(),
+            articleOnPrivateMap.getId())
             .orElseThrow(() -> new IllegalArgumentException("해당되는 유저나 게시글이 없어서 테스트 실패"));
 
         //then
         assertThat(articleLikeTest).isNotNull();
         assertThat(articleLikeTest.getUser().getId()).isEqualTo(savedUser1.getId());
-        assertThat(articleLikeTest.getArticle().getId()).isEqualTo(savedArticle1.getId());
+        assertThat(articleLikeTest.getArticle().getId()).isEqualTo(articleOnPrivateMap.getId());
     }
 
     @Test
@@ -62,28 +69,64 @@ class ArticleLikeRepositoryTest {
         //given
 
         //when
-        int totalLikes1 = articleLikeRepository.countByArticleId(savedArticle1.getId());
-        int totalLikes2 = articleLikeRepository.countByArticleId(savedArticle2.getId());
+        Long totalLikes1 = articleLikeRepository.countByArticleId(articleOnPrivateMap.getId());
+        Long totalLikes2 = articleLikeRepository.countByArticleId(articleOnPublicMap.getId());
 
         //then
         assertThat(totalLikes1).isEqualTo(2);
-        assertThat(totalLikes2).isEqualTo(0);
+        assertThat(totalLikes2).isEqualTo(2);
     }
 
     @Test
     @Transactional
-    void countByUserIdAndArticleId() {
+    void countOfPublicArticle() {
         //given
 
         //when
-        int count1 = articleLikeRepository.countByUserIdAndArticleId(savedUser1.getId(),savedArticle1.getId());
-        int count2 = articleLikeRepository.countByUserIdAndArticleId(savedUser2.getId(),savedArticle1.getId());
-        int count3 = articleLikeRepository.countByUserIdAndArticleId(savedUser1.getId(),savedArticle2.getId());
+        Long count1 = articleLikeRepository.countOfPublicArticle(articleOnPublicMap.getId(),
+            savedUser1.getId());
+        Long count2 = articleLikeRepository.countOfPublicArticle(articleOnPublicMap.getId(),
+            savedUser2.getId());
 
         //then
         assertThat(count1).isEqualTo(1);
         assertThat(count2).isEqualTo(1);
-        assertThat(count3).isEqualTo(0);
+
+    }
+
+    @Test
+    @Transactional
+    void countOfPrivateArticle() {
+        //given
+
+        //when
+        Long count1 = articleLikeRepository.countOfPrivateArticle(articleOnPrivateMap.getId(),
+            savedUser1.getId());
+        Long count2 = articleLikeRepository.countOfPrivateArticle(articleOnPrivateMap.getId(),
+            savedUser2.getId());
+
+        //then
+        assertThat(count1).isEqualTo(1);
+        assertThat(count2).isEqualTo(0);
+    }
+
+    @Test
+    @Transactional
+    void countOfGroupedArticle() {
+        //given
+        Group group1=persistGroup(testEntityManager);
+        persistArticleGroup(testEntityManager, articleOnPublicMap, group1);
+        persistUserGroup(testEntityManager, savedUser2, group1);
+
+        //when
+        Long count1 = articleLikeRepository.countOfGroupedArticle(articleOnPublicMap.getId(),
+            savedUser1.getId());
+        Long count2 = articleLikeRepository.countOfGroupedArticle(articleOnPublicMap.getId(),
+            savedUser2.getId());
+
+        //then
+        assertThat(count1).isEqualTo(0);
+        assertThat(count2).isEqualTo(1);
     }
 
     private ArticleLike persistArticleLike(User user, Article article) {

--- a/frontend/rush/src/api/ChangeMyLikeApi.js
+++ b/frontend/rush/src/api/ChangeMyLikeApi.js
@@ -2,7 +2,7 @@ import React from 'react';
 import axios from "axios";
 import {BACKEND_ADDRESS} from "../constants/ADDRESS";
 
-const changeMyLikingApi = (accessToken, hasILiked, articleId, mapType, history) => {
+const changeMyLikeApi = (accessToken, hasILiked, articleId, mapType, history) => {
   if (!accessToken) {
     alert("로그인이 필요한 서비스입니다.")
     history.push('/login');
@@ -31,4 +31,4 @@ const changeMyLikingApi = (accessToken, hasILiked, articleId, mapType, history) 
   });
 };
 
-export default changeMyLikingApi;
+export default changeMyLikeApi;

--- a/frontend/rush/src/api/ChangeMyLikingApi.js
+++ b/frontend/rush/src/api/ChangeMyLikingApi.js
@@ -2,7 +2,7 @@ import React from 'react';
 import axios from "axios";
 import {BACKEND_ADDRESS} from "../constants/ADDRESS";
 
-const changeMyLikingApi = (accessToken, hasILiked, articleId,history) => {
+const changeMyLikingApi = (accessToken, hasILiked, articleId, mapType, history) => {
   if (!accessToken) {
     alert("로그인이 필요한 서비스입니다.")
     history.push('/login');
@@ -15,7 +15,7 @@ const changeMyLikingApi = (accessToken, hasILiked, articleId,history) => {
     }
   }
 
-  axios.post(BACKEND_ADDRESS + "/articles/" + articleId + "/like?hasiliked=" + hasILiked,{}, config)
+  axios.post(BACKEND_ADDRESS + "/articles/" +mapType + "/" + articleId + "/like?hasiliked=" + hasILiked,{}, config)
   .then(response => {
     if (response.status === 201) {
     }

--- a/frontend/rush/src/api/CheckHasILikedApi.js
+++ b/frontend/rush/src/api/CheckHasILikedApi.js
@@ -1,13 +1,13 @@
 import axios from "axios";
 import {BACKEND_ADDRESS} from "../constants/ADDRESS";
 
-const checkHasILikedApi = (accessToken, articleId) => {
+const checkHasILikedApi = (accessToken, articleId, mapType) => {
   const config = {
     headers: {
       "Authorization": "Bearer " + accessToken
     }
   };
-  return axios.get(BACKEND_ADDRESS + "/articles/" + articleId + "/like", config)
+  return axios.get(BACKEND_ADDRESS + "/articles/" + mapType + "/" + articleId + "/like", config)
   .then(response => response.data);
 };
 

--- a/frontend/rush/src/components/articleDetail/ArticleBody.js
+++ b/frontend/rush/src/components/articleDetail/ArticleBody.js
@@ -1,18 +1,18 @@
 import React from 'react';
 import ArticleTitle from "./ArticleTitle";
 import styled from "styled-components";
-import changeMyLikingApi from "../../api/ChangeMyLikingApi";
+import changeMyLikeApi from "../../api/ChangeMyLikeApi";
 
 const ArticleContent = styled.div`
   font-size: 24px;
   margin-top: 10px;
 `
 
-const ArticleLiking = styled.div`
+const ArticleLike = styled.div`
   display: flex;
 `
 
-const LikingHeart = styled.div`
+const LikeHeart = styled.div`
   font-size: 40px;
   margin-top: 10px;
   color: rgb(90, 155, 213);
@@ -26,7 +26,7 @@ const LikingHeart = styled.div`
   user-select: none;
  `
 
-const LikingLetter = styled.div`
+const LikeLetter = styled.div`
   font-size: 17px;
   margin-left:7px;
   padding-top:26px;
@@ -41,16 +41,16 @@ const ArticleBody = (props) => {
         <ArticleContent>
           {props.article ? props.article.content : ""}
         </ArticleContent>
-        <ArticleLiking>
-          <LikingHeart
+        <ArticleLike>
+          <LikeHeart
             onClick={() => {
               props.setArticleTotalLikes(props.hasILiked?props.articleTotalLikes-1 : props.articleTotalLikes+1);
-              changeMyLikingApi(props.accessToken, props.hasILiked, props.articleId, props.mapType, props.history);
+              changeMyLikeApi(props.accessToken, props.hasILiked, props.articleId, props.mapType, props.history);
               props.setHasILiked(!props.hasILiked);
               }
-            }>{props.hasILiked?"♥":"♡"} </LikingHeart>
-          <LikingLetter>좋아요 {props.article ? props.articleTotalLikes : ""}개</LikingLetter>
-        </ArticleLiking>
+            }>{props.hasILiked?"♥":"♡"} </LikeHeart>
+          <LikeLetter>좋아요 {props.article ? props.articleTotalLikes : ""}개</LikeLetter>
+        </ArticleLike>
       </div>
   );
 };

--- a/frontend/rush/src/components/articleDetail/ArticleBody.js
+++ b/frontend/rush/src/components/articleDetail/ArticleBody.js
@@ -45,7 +45,7 @@ const ArticleBody = (props) => {
           <LikingHeart
             onClick={() => {
               props.setArticleTotalLikes(props.hasILiked?props.articleTotalLikes-1 : props.articleTotalLikes+1);
-              changeMyLikingApi(props.accessToken, props.hasILiked, props.articleId, props.history);
+              changeMyLikingApi(props.accessToken, props.hasILiked, props.articleId, props.mapType, props.history);
               props.setHasILiked(!props.hasILiked);
               }
             }>{props.hasILiked?"♥":"♡"} </LikingHeart>

--- a/frontend/rush/src/components/articleDetail/ArticleDetailPage.js
+++ b/frontend/rush/src/components/articleDetail/ArticleDetailPage.js
@@ -10,7 +10,7 @@ import findCommentsApi from "../../api/FindCommentsApi";
 import {ACCESS_TOKEN} from "../../constants/SessionStorage";
 import {withRouter} from "react-router-dom";
 import {GROUPED, PRIVATE, PUBLIC} from "../../constants/MapType";
-import CheckHasIlikedApi from "../../api/CheckHasILikedApi";
+import checkHasIlikedApi from "../../api/CheckHasILikedApi";
 
 const ArticleDetailPage = (props) => {
   const accessToken = sessionStorage.getItem(ACCESS_TOKEN);
@@ -36,10 +36,10 @@ const ArticleDetailPage = (props) => {
 
   useEffect(()=>{
     if(accessToken)
-    CheckHasIlikedApi(accessToken, articleId).then(hasILiked =>{
+    checkHasIlikedApi(accessToken, articleId, mapType).then(hasILiked =>{
       setHasILiked(hasILiked);
     })
-  },[]);
+  },[articleId]);
 
   useEffect(() => {
     findCommentsApi({
@@ -48,7 +48,6 @@ const ArticleDetailPage = (props) => {
       history: props.history}
     ).then(commentPromise => {
       setComments(commentPromise)
-      console.log(commentPromise)
     });
   }, [articleId]);
 
@@ -71,6 +70,7 @@ const ArticleDetailPage = (props) => {
           <ArticleBody
             accessToken={accessToken}
             articleId={articleId}
+            mapType={mapType}
             article={article}
             articleTotalLikes={articleTotalLikes}
             setArticleTotalLikes={setArticleTotalLikes}

--- a/frontend/rush/src/components/articleDetail/CommentWriting.js
+++ b/frontend/rush/src/components/articleDetail/CommentWriting.js
@@ -36,14 +36,19 @@ const CommentWriting = ({articleId, comments, setComments, mapType, accessToken,
             placeholder="댓글을 입력해주세요 :)"
         />
         <CommentWritingButton onClick={() => {
-          createCommentApi(inputValue,
-              articleId,
-              mapType,
-              accessToken,
-              history
-          ).then(commentPromise => {
-            setComments(new Array(commentPromise).concat(comments))
-          })
+          if(inputValue.length === 0)
+            alert("댓글을 채워주세요!");
+          else{
+            setInputValue("");
+            createCommentApi(inputValue,
+                articleId,
+                mapType,
+                accessToken,
+                history
+            ).then(commentPromise => {
+              setComments(new Array(commentPromise).concat(comments))
+            })
+          }
         }}>
           등록
         </CommentWritingButton>

--- a/frontend/rush/src/components/home/DefaultMap.js
+++ b/frontend/rush/src/components/home/DefaultMap.js
@@ -66,6 +66,7 @@ const DefaultMap = withScriptjs(withGoogleMap((props) => {
             },
           }}
           onClick={() => {
+            props.setIsMenuOpen(false);
             setInfoWindowPostId(null);
           }}
           onZoomChanged={()=>{

--- a/frontend/rush/src/components/home/DefaultMapPage.js
+++ b/frontend/rush/src/components/home/DefaultMapPage.js
@@ -23,7 +23,7 @@ import findGroupApi from "../../api/FindGroupApi";
 const DefaultMapPage = (props) => {
   const LatRangeRatio = 0.561906;
   const LngRangeRatio = 0.70378;
-
+  const [isMenuOpen,setIsMenuOpen] = useState(false);
   const [windowSize, setWindowSize] = useState(WindowSize());
   // 사용자 관련
   const accessToken = sessionStorage.getItem(ACCESS_TOKEN);
@@ -104,8 +104,11 @@ const DefaultMapPage = (props) => {
                 setCenter={setCenter}
                 latitudeRange={latitudeRange}
                 longitudeRange={longitudeRange}
+                setIsMenuOpen={setIsMenuOpen}
     />
     <Menu
+      isMenuOpen={isMenuOpen}
+      setIsMenuOpen={setIsMenuOpen}
       isGroupOpened={isGroupOpened}
       setIsGroupOpened={setIsGroupOpened}
       setMapType={setMapType}

--- a/frontend/rush/src/components/home/button/MenuButton.js
+++ b/frontend/rush/src/components/home/button/MenuButton.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {bubble as BurgerMenu} from "react-burger-menu";
 import "./styled.css";
 import styled from "styled-components";
@@ -14,21 +14,23 @@ const BurgerMenuContents = styled.div`
   cursor: pointer;
 `;
 
-const Menu = ({isGroupOpened, setIsGroupOpened, setMapType, setGroupId, setIsCreateGroupModalOpen,  setIsJoinGroupModalOpen, accessToken, history}) => {
-
+const Menu = ({isMenuOpen, setIsMenuOpen, isGroupOpened, setIsGroupOpened, setMapType, setGroupId, setIsCreateGroupModalOpen,  setIsJoinGroupModalOpen, accessToken, history}) => {
   const url = accessToken? "/mypage" : "/login";
-  const [isMenuOpen,setIsMenuOpen] = useState(false);
+  useEffect(()=>{
+    if(!isMenuOpen)
+      setIsGroupOpened(false);
+  },[isMenuOpen]);
+
   return (<>
     <BurgerMenu
-        onOpen={()=>setIsMenuOpen(true)}
-        onClose={()=>{
-          setIsMenuOpen(false);
-          setIsGroupOpened(false);
-        }}
         isOpen={isMenuOpen}
+        onStateChange={(state)=>{setIsMenuOpen(state.isOpen)}}
         disableAutoFocus>
       <BurgerMenuContents onClick={() => history.push(url)}>마이페이지</BurgerMenuContents>
-      <BurgerMenuContents onClick={() => setMapType(PUBLIC)}>전체지도</BurgerMenuContents>
+      <BurgerMenuContents onClick={() => {
+        setMapType(PUBLIC);
+        setIsMenuOpen(false);
+      }}>전체지도</BurgerMenuContents>
       <BurgerMenuContents onClick={() => setIsGroupOpened(!isGroupOpened)}>
         그룹지도
       </BurgerMenuContents>
@@ -41,7 +43,10 @@ const Menu = ({isGroupOpened, setIsGroupOpened, setMapType, setGroupId, setIsCre
           setIsCreateGroupModalOpen={setIsCreateGroupModalOpen}
           setIsJoinGroupModalOpen={setIsJoinGroupModalOpen}
       />
-      <BurgerMenuContents onClick={() => setMapType(PRIVATE)}>개인지도</BurgerMenuContents>
+      <BurgerMenuContents onClick={() => {
+        setMapType(PRIVATE);
+        setIsMenuOpen(false);
+      }}>개인지도</BurgerMenuContents>
     </BurgerMenu>
   </>);
 }

--- a/frontend/rush/src/components/home/group/GroupContent.js
+++ b/frontend/rush/src/components/home/group/GroupContent.js
@@ -10,10 +10,11 @@ const GroupContentStyle = styled.li`
   cursor: pointer;
 `;
 
-const GroupContent = ({groupName, groupId, setMapType, setGroupId}) => {
+const GroupContent = ({setIsMenuOpen, groupName, groupId, setMapType, setGroupId}) => {
   const onClick = () => {
     setMapType(GROUPED);
     setGroupId(groupId);
+    setIsMenuOpen(false);
   };
 
   return (

--- a/frontend/rush/src/components/home/group/GroupList.js
+++ b/frontend/rush/src/components/home/group/GroupList.js
@@ -44,6 +44,7 @@ const GroupList = (props) => {
             {
               groups ? groups.map(group =>
                 <GroupContent
+                  setIsMenuOpen={props.setIsMenuOpen}
                   groupName={group.name}
                   groupId={group.id}
                   setMapType={props.setMapType}


### PR DESCRIPTION
**이슈 번호**

resolved: #122 

**작업 내용**

1. 좋아요 권한설정
2. 프론트 일부 개선
    1. 좋아요 명칭 liking -> like로 수정
    2. 빈 댓글입력시 경고나오게 수정 
    3. 댓글입력시 댓글입력창을 비움
    4. 다음과 같은 행동을 할시 매뉴바가 닫힘 -(매뉴바 안에 있는 전체지도 클릭, 개인지도 클릭, 각각의 그룹지도 클릭, 화면의 지도 아무데나 클릭)



**테스트 작성 여부**

- [X] Test case

**주의 사항**