### PR TITLE
fix: flyway 적용 후 DataJpaTest 깨지는 문제 해결

### DIFF
--- a/backend/rush/src/test/java/rush/rush/repository/ArticleGroupRepositoryTest.java
+++ b/backend/rush/src/test/java/rush/rush/repository/ArticleGroupRepositoryTest.java
@@ -2,15 +2,17 @@ package rush.rush.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static rush.rush.repository.SetUpMethods.persistArticle;
-import static rush.rush.repository.SetUpMethods.persistGroup;
 import static rush.rush.repository.SetUpMethods.persistUser;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 import rush.rush.domain.Article;
@@ -20,6 +22,9 @@ import rush.rush.domain.User;
 
 @ExtendWith(SpringExtension.class)  // junit5에게 Spring support를 enable 하라고 말하는거
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Sql("/init-table.sql")
 class ArticleGroupRepositoryTest {
 
     @Autowired

--- a/backend/rush/src/test/java/rush/rush/repository/ArticleGroupRepositoryTest.java
+++ b/backend/rush/src/test/java/rush/rush/repository/ArticleGroupRepositoryTest.java
@@ -6,32 +6,17 @@ import static rush.rush.repository.SetUpMethods.persistUser;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 import rush.rush.domain.Article;
 import rush.rush.domain.ArticleGroup;
 import rush.rush.domain.Group;
 import rush.rush.domain.User;
 
-@ExtendWith(SpringExtension.class)  // junit5에게 Spring support를 enable 하라고 말하는거
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("test")
-@Sql("/init-table.sql")
-class ArticleGroupRepositoryTest {
+class ArticleGroupRepositoryTest extends RepositoryTest {
 
     @Autowired
     private ArticleGroupRepository articleGroupRepository;
-
-    @Autowired
-    private TestEntityManager testEntityManager;
 
     @Test
     @Transactional

--- a/backend/rush/src/test/java/rush/rush/repository/ArticleLikeRepositoryTest.java
+++ b/backend/rush/src/test/java/rush/rush/repository/ArticleLikeRepositoryTest.java
@@ -11,8 +11,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 import rush.rush.domain.Article;
@@ -22,6 +25,9 @@ import rush.rush.domain.User;
 
 @ExtendWith(SpringExtension.class)  // junit5에게 Spring support를 enable 하라고 말하는거
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Sql("/init-table.sql")
 class ArticleLikeRepositoryTest {
 
     @Autowired

--- a/backend/rush/src/test/java/rush/rush/repository/ArticleLikeRepositoryTest.java
+++ b/backend/rush/src/test/java/rush/rush/repository/ArticleLikeRepositoryTest.java
@@ -9,32 +9,17 @@ import static rush.rush.repository.SetUpMethods.persistUserGroup;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 import rush.rush.domain.Article;
 import rush.rush.domain.ArticleLike;
 import rush.rush.domain.Group;
 import rush.rush.domain.User;
 
-@ExtendWith(SpringExtension.class)  // junit5에게 Spring support를 enable 하라고 말하는거
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("test")
-@Sql("/init-table.sql")
-class ArticleLikeRepositoryTest {
+class ArticleLikeRepositoryTest  extends RepositoryTest {
 
     @Autowired
     ArticleLikeRepository articleLikeRepository;
-
-    @Autowired
-    private TestEntityManager testEntityManager;
 
     User savedUser1;
     User savedUser2;

--- a/backend/rush/src/test/java/rush/rush/repository/ArticleRepositoryTest.java
+++ b/backend/rush/src/test/java/rush/rush/repository/ArticleRepositoryTest.java
@@ -11,32 +11,17 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 import rush.rush.domain.Article;
 import rush.rush.domain.ArticleGroup;
 import rush.rush.domain.Group;
 import rush.rush.domain.User;
 
-@ExtendWith(SpringExtension.class)  // junit5에게 Spring support를 enable 하라고 말하는거
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("test")
-@Sql("/init-table.sql")
-class ArticleRepositoryTest {
+class ArticleRepositoryTest extends RepositoryTest {
 
     @Autowired
     private ArticleRepository articleRepository;
-
-    @Autowired
-    private TestEntityManager testEntityManager;
 
     @Test
     @Transactional

--- a/backend/rush/src/test/java/rush/rush/repository/ArticleRepositoryTest.java
+++ b/backend/rush/src/test/java/rush/rush/repository/ArticleRepositoryTest.java
@@ -13,8 +13,11 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 import rush.rush.domain.Article;
@@ -24,6 +27,9 @@ import rush.rush.domain.User;
 
 @ExtendWith(SpringExtension.class)  // junit5에게 Spring support를 enable 하라고 말하는거
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Sql("/init-table.sql")
 class ArticleRepositoryTest {
 
     @Autowired

--- a/backend/rush/src/test/java/rush/rush/repository/CommentRepositoryTest.java
+++ b/backend/rush/src/test/java/rush/rush/repository/CommentRepositoryTest.java
@@ -10,34 +10,19 @@ import static rush.rush.repository.SetUpMethods.persistUserGroup;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 import rush.rush.domain.Article;
 import rush.rush.domain.Comment;
 import rush.rush.domain.Group;
 import rush.rush.domain.User;
 
-@ExtendWith(SpringExtension.class)
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("test")
-@Sql("/init-table.sql")
-class CommentRepositoryTest {
+class CommentRepositoryTest extends RepositoryTest {
 
     public static final String COMMENT_CONTENT = "댓글내용임 ㅇㅇㅇㅇ";
 
     @Autowired
     private CommentRepository commentRepository;
-
-    @Autowired
-    private TestEntityManager testEntityManager;
 
     @Test
     @Transactional

--- a/backend/rush/src/test/java/rush/rush/repository/CommentRepositoryTest.java
+++ b/backend/rush/src/test/java/rush/rush/repository/CommentRepositoryTest.java
@@ -12,8 +12,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 import rush.rush.domain.Article;
@@ -23,6 +26,9 @@ import rush.rush.domain.User;
 
 @ExtendWith(SpringExtension.class)
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Sql("/init-table.sql")
 class CommentRepositoryTest {
 
     public static final String COMMENT_CONTENT = "댓글내용임 ㅇㅇㅇㅇ";

--- a/backend/rush/src/test/java/rush/rush/repository/GroupRepositoryTest.java
+++ b/backend/rush/src/test/java/rush/rush/repository/GroupRepositoryTest.java
@@ -10,8 +10,11 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 import rush.rush.domain.Group;
@@ -19,6 +22,9 @@ import rush.rush.domain.User;
 
 @ExtendWith(SpringExtension.class)  // junit5에게 Spring support를 enable 하라고 말하는거
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Sql("/init-table.sql")
 class GroupRepositoryTest {
 
     @Autowired

--- a/backend/rush/src/test/java/rush/rush/repository/GroupRepositoryTest.java
+++ b/backend/rush/src/test/java/rush/rush/repository/GroupRepositoryTest.java
@@ -8,30 +8,15 @@ import static rush.rush.repository.SetUpMethods.persistUserGroup;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 import rush.rush.domain.Group;
 import rush.rush.domain.User;
 
-@ExtendWith(SpringExtension.class)  // junit5에게 Spring support를 enable 하라고 말하는거
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("test")
-@Sql("/init-table.sql")
-class GroupRepositoryTest {
+class GroupRepositoryTest extends RepositoryTest {
 
     @Autowired
     private GroupRepository groupRepository;
-
-    @Autowired
-    private TestEntityManager testEntityManager;
 
     @Test
     @Transactional

--- a/backend/rush/src/test/java/rush/rush/repository/RepositoryTest.java
+++ b/backend/rush/src/test/java/rush/rush/repository/RepositoryTest.java
@@ -1,0 +1,21 @@
+package rush.rush.repository;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)  // junit5에게 Spring support를 enable 하라고 말하는거
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Sql("/init-table.sql")
+public abstract class RepositoryTest {
+
+    @Autowired
+    protected TestEntityManager testEntityManager;
+}

--- a/backend/rush/src/test/java/rush/rush/repository/UserGroupRepositoryTest.java
+++ b/backend/rush/src/test/java/rush/rush/repository/UserGroupRepositoryTest.java
@@ -8,8 +8,11 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 import rush.rush.domain.Group;
@@ -18,6 +21,9 @@ import rush.rush.domain.UserGroup;
 
 @ExtendWith(SpringExtension.class)  // junit5에게 Spring support를 enable 하라고 말하는거
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Sql("/init-table.sql")
 class UserGroupRepositoryTest {
 
     @Autowired

--- a/backend/rush/src/test/java/rush/rush/repository/UserGroupRepositoryTest.java
+++ b/backend/rush/src/test/java/rush/rush/repository/UserGroupRepositoryTest.java
@@ -6,31 +6,16 @@ import static rush.rush.repository.SetUpMethods.persistUser;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 import rush.rush.domain.Group;
 import rush.rush.domain.User;
 import rush.rush.domain.UserGroup;
 
-@ExtendWith(SpringExtension.class)  // junit5에게 Spring support를 enable 하라고 말하는거
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("test")
-@Sql("/init-table.sql")
-class UserGroupRepositoryTest {
+class UserGroupRepositoryTest extends RepositoryTest {
 
     @Autowired
     private UserGroupRepository userGroupRepository;
-
-    @Autowired
-    private TestEntityManager testEntityManager;
 
     @Test
     @Transactional

--- a/backend/rush/src/test/java/rush/rush/repository/UserRepositoryTest.java
+++ b/backend/rush/src/test/java/rush/rush/repository/UserRepositoryTest.java
@@ -7,30 +7,15 @@ import static rush.rush.repository.SetUpMethods.persistUserGroup;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 import rush.rush.domain.Group;
 import rush.rush.domain.User;
 
-@ExtendWith(SpringExtension.class)
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("test")
-@Sql("/init-table.sql")
-class UserRepositoryTest {
+class UserRepositoryTest extends RepositoryTest {
 
     @Autowired
     private UserRepository userRepository;
-
-    @Autowired
-    private TestEntityManager testEntityManager;
 
     @Test
     @Transactional

--- a/backend/rush/src/test/java/rush/rush/repository/UserRepositoryTest.java
+++ b/backend/rush/src/test/java/rush/rush/repository/UserRepositoryTest.java
@@ -9,8 +9,11 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 import rush.rush.domain.Group;
@@ -18,6 +21,9 @@ import rush.rush.domain.User;
 
 @ExtendWith(SpringExtension.class)
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Sql("/init-table.sql")
 class UserRepositoryTest {
 
     @Autowired

--- a/backend/rush/src/test/resources/application-test.yml
+++ b/backend/rush/src/test/resources/application-test.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    driverClassName: org.h2.Driver
+    password: password
+    url: jdbc:h2:mem:testdb;MODE=Mysql;
+    username: sa
+  jpa:
+    database-platform: org.hibernate.dialect.MariaDB103Dialect
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: true
+    show-sql: true

--- a/backend/rush/src/test/resources/init-table.sql
+++ b/backend/rush/src/test/resources/init-table.sql
@@ -1,0 +1,7 @@
+delete from article_group;
+delete from user_group;
+delete from article_like;
+delete from comment;
+delete from article;
+delete from user;
+delete from group_table;


### PR DESCRIPTION
**이슈 번호**

resolved: #145 

**작업 내용**

1. AutoConfigureTestDatabase 를 NONE 으로 바꾼다음 application-test.yml 을 적용해서 테스트DB 설정을 직접 함. 이를 통해 H2 DB에 ;MODE=Mysql 을 적용함.
      - 이 방법을 알려준 링크 : [How to Add the Mode Mysql To Embedded H2 DB in Spring Boot](https://stackoverflow.com/questions/42364935/how-to-add-the-mode-mysql-to-embedded-h2-db-in-spring-boot-1-4-1-for-datajpates)
2. 1번 방법의 적용으로 인해 `@Transactional`을 통한 DB 롤백 기능이 지원되지 않음 -> init-table.sql 을 이용해서 수동으로 롤백 기능 적용

**테스트 작성 여부**

- [x] Test case

**주의 사항**