### PR TITLE
fix: ArticleRepository findArticleAuthorId JPQL에서 명시적 inner join 제거

### DIFF
--- a/backend/rush/src/main/java/rush/rush/repository/ArticleRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/ArticleRepository.java
@@ -86,6 +86,6 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
         + "order by article.createDate desc")
     List<Article> findArticlesWithGroupsByUserId(@Param("userId") Long userId);
 
-    @Query("select distinct article.user.id from Article article inner join article.user")
+    @Query("select distinct article.user.id from Article article")
     Optional<Long> findArticleAuthorId(@Param("articleId") Long articleId);
 }


### PR DESCRIPTION
**이슈 번호**

resolved: #157 

**작업 내용**

ArticleRepository findArticleAuthorId JPQL에서 명시적 inner join 제거

**테스트 작성 여부**

- [ ] Test case

**주의 사항**
왜 로컬은 잘되고 서버에선 계속 터지냐고.....ㅂㄷㅂㄷ