### PR TITLE
refactor: 프론트 게시글 받아오는 범위 수정

### DIFF
--- a/frontend/rush/src/components/articleDetail/ArticleDetailPage.js
+++ b/frontend/rush/src/components/articleDetail/ArticleDetailPage.js
@@ -13,7 +13,6 @@ import {GROUPED, PRIVATE, PUBLIC} from "../../constants/MapType";
 import checkHasILikedApi from "../../api/CheckHasILikedApi";
 import checkHasIlikedInCommentApi from "../../api/CheckHasIlikedInCommentApi";
 import isMyArticleApi from "../../api/IsMyArticleApi";
-import checkHasILikedApi from "../../api/CheckHasILikedApi";
 
 const ArticleDetailPage = (props) => {
   const accessToken = sessionStorage.getItem(ACCESS_TOKEN);

--- a/frontend/rush/src/components/home/DefaultMapPage.js
+++ b/frontend/rush/src/components/home/DefaultMapPage.js
@@ -56,9 +56,9 @@ const DefaultMapPage = (props) => {
 
   useEffect(() => {
     setLatitudeRange(
-      LatRangeRatio * windowSize.height * Math.pow(0.5, zoom - 1));
+      LatRangeRatio * windowSize.height * Math.pow(0.5, zoom - 2));
     setLongitudeRange(
-      LngRangeRatio * windowSize.width * Math.pow(0.5, zoom - 1));
+      LngRangeRatio * windowSize.width * Math.pow(0.5, zoom - 2));
   }, [zoom]);
 
   useEffect(() => {


### PR DESCRIPTION
**이슈 번호**

resolved: #167 

**작업 내용**

1. 프론트 게시글 받아오는 지도의 범위를 두배로 증가시켰다

**테스트 작성 여부**

- [ ] Test case

**주의 사항**