### PR TITLE
refactor: articles를 가져오기 위한 center의 변동범위를 줄임

### DIFF
--- a/frontend/rush/src/components/home/DefaultMap.js
+++ b/frontend/rush/src/components/home/DefaultMap.js
@@ -72,8 +72,8 @@ const DefaultMap = withScriptjs(withGoogleMap((props) => {
             props.setCenter(mapRef.current.getCenter());
           }}
           onCenterChanged={() =>{
-            let latChangeRange= Math.abs(props.center.lat()-mapRef.current.getCenter().lat())>(5*props.latitudeRange/12);
-            let lngChangeRange= Math.abs(props.center.lng()-mapRef.current.getCenter().lng())>(5*props.longitudeRange/12);
+            let latChangeRange= Math.abs(props.center.lat()-mapRef.current.getCenter().lat())>(props.latitudeRange/4);
+            let lngChangeRange= Math.abs(props.center.lng()-mapRef.current.getCenter().lng())>(props.longitudeRange/4);
             let dummy= (latChangeRange || lngChangeRange)?props.setCenter(mapRef.current.getCenter()): "";
           }}
       >


### PR DESCRIPTION
**이슈 번호**

resolved: #179 

**작업 내용**

1. 게시글들을 가져오기 위한 get 요청을 실행시키는 범위를 수정하여 지도에 마커를 가져오는데 있어 더욱 부드럽게 한다.
**테스트 작성 여부**

- [ ] Test case

**주의 사항**