### PR TITLE
refactor: 홈화면에서 마커들이 바로 나오지 않는 문제 해결 및 글쓰기 페이지 현위치 버튼 추가 

### DIFF
--- a/backend/rush/src/main/java/rush/rush/domain/LocationRange.java
+++ b/backend/rush/src/main/java/rush/rush/domain/LocationRange.java
@@ -14,7 +14,7 @@ public class LocationRange {
             Double startLongitude, Double longitudeRange) {
         this.lowerLatitude = startLatitude - latitudeRange;
         this.upperLatitude = startLatitude + latitudeRange;
-        this.lowerLongitude = startLongitude - latitudeRange;
+        this.lowerLongitude = startLongitude - longitudeRange;
         this.upperLongitude = startLongitude + longitudeRange;
     }
 }

--- a/frontend/rush/src/components/home/DefaultMapPage.js
+++ b/frontend/rush/src/components/home/DefaultMapPage.js
@@ -54,6 +54,18 @@ const DefaultMapPage = (props) => {
   useEffect(() => {
     navigator.geolocation.getCurrentPosition(function (position) {
       setDefaultCenter({lat: position.coords.latitude, lng: position.coords.longitude});
+      if(props.location.state){
+        setCenter({
+          lat: () => props.location.state.lat,
+          lng: () => props.location.state.lng
+        });
+      }
+      else {
+        setCenter({
+          lat: () => position.coords.latitude,
+          lng: () => position.coords.longitude
+        });
+      }
     })},[]);
 
   useEffect(() => {

--- a/frontend/rush/src/components/home/DefaultMapPage.js
+++ b/frontend/rush/src/components/home/DefaultMapPage.js
@@ -184,6 +184,7 @@ const DefaultMapPage = (props) => {
     />
     <WriteButton
       accessToken={accessToken}
+      center={center}
       defaultCenter={defaultCenter}
     />
   </>);

--- a/frontend/rush/src/components/home/DefaultMapPage.js
+++ b/frontend/rush/src/components/home/DefaultMapPage.js
@@ -54,18 +54,10 @@ const DefaultMapPage = (props) => {
   useEffect(() => {
     navigator.geolocation.getCurrentPosition(function (position) {
       setDefaultCenter({lat: position.coords.latitude, lng: position.coords.longitude});
-      if(props.location.state){
-        setCenter({
-          lat: () => props.location.state.lat,
-          lng: () => props.location.state.lng
-        });
-      }
-      else {
-        setCenter({
-          lat: () => position.coords.latitude,
-          lng: () => position.coords.longitude
-        });
-      }
+      setCenter({
+        lat: () => props.location.state? props.location.state.lat: position.coords.latitude,
+        lng: () => props.location.state? props.location.state.lng: position.coords.longitude
+      });
     })},[]);
 
   useEffect(() => {

--- a/frontend/rush/src/components/home/DefaultMapPage.js
+++ b/frontend/rush/src/components/home/DefaultMapPage.js
@@ -178,6 +178,7 @@ const DefaultMapPage = (props) => {
         />
     }
     <MyLocationButton
+      setCenter={setCenter}
       defaultCenter={defaultCenter}
       setMyLocation={setMyLocation}
     />

--- a/frontend/rush/src/components/home/button/MyLocationButton.js
+++ b/frontend/rush/src/components/home/button/MyLocationButton.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const MyLocationButton = ({defaultCenter, setMyLocation}) => {
+const MyLocationButton = ({setCenter, defaultCenter, setMyLocation}) => {
   return (<img
           src="/myLocation.png"
           alt="my image"
@@ -14,9 +14,14 @@ const MyLocationButton = ({defaultCenter, setMyLocation}) => {
             margin: "10px",
             cursor: "pointer"
           }}
-          onClick={()=>{setMyLocation({
-            lat: defaultCenter.lat+0.00000000000000000001,
-            lng: defaultCenter.lng+0.00000000000000000001,
+          onClick={()=>{
+            setCenter({
+              lat: () => defaultCenter.lat,
+              lng: () => defaultCenter.lng
+            })
+            setMyLocation({
+              lat: defaultCenter.lat+0.00000000000000000001,
+              lng: defaultCenter.lng+0.00000000000000000001,
           })}}
       />
   );

--- a/frontend/rush/src/components/home/button/WriteButton.js
+++ b/frontend/rush/src/components/home/button/WriteButton.js
@@ -8,7 +8,9 @@ const WriteButton = (props) => {
       <Link to={{
         pathname: url,
         state: {
-          defaultCenter: props.defaultCenter
+          lat: props.center.lat(),
+          lng: props.center.lng(),
+          myLocation: props.defaultCenter
         }
       }}>
         <button style={{

--- a/frontend/rush/src/components/writing/MyLocationButton.js
+++ b/frontend/rush/src/components/writing/MyLocationButton.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const MyLocationButton = ({step, setCenter, myLocation}) => {
+  return <>{(step === 1) && <img
+      src="/myLocation.png"
+      alt="my image"
+      style={{
+        position: "fixed",
+        zIndex: 10,
+        bottom: "30px",
+        right: "-22px",
+        width: "150px",
+        height: "150px",
+        margin: "10px",
+        cursor: "pointer"
+      }}
+      onClick={() => {
+        setCenter({
+          lat: () => myLocation.lat,
+          lng: () => myLocation.lng
+        })
+      }}
+  />}
+  </>
+};
+
+export default MyLocationButton;

--- a/frontend/rush/src/components/writing/WritingPage.js
+++ b/frontend/rush/src/components/writing/WritingPage.js
@@ -11,8 +11,8 @@ import {Redirect, withRouter} from "react-router-dom";
 const WritingPage = (props) => {
   const [step, setStep] = useState(1);
   const [center, setCenter] = useState({
-    lat: () => props.location.state.defaultCenter.lat,
-    lng: () => props.location.state.defaultCenter.lng
+    lat: () => props.location.state.lat,
+    lng: () => props.location.state.lng
   });
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
@@ -32,7 +32,7 @@ const WritingPage = (props) => {
                     loadingElement={<div style={{height: `100%`}}/>}
                     containerElement={<div style={{height: WindowSize().height}}/>}
                     mapElement={<div style={{height: `100%`}}/>}
-                    defaultCenter={props.location.state.defaultCenter}
+                    defaultCenter={{lat: props.location.state.lat, lng:  props.location.state.lng}}
                     center={center}
                     setCenter={setCenter}
         />

--- a/frontend/rush/src/components/writing/WritingPage.js
+++ b/frontend/rush/src/components/writing/WritingPage.js
@@ -7,6 +7,7 @@ import WritingStep3Modal from "./step3/WritingStep3Modal";
 import WindowSize from "../../util/WindowSize";
 import {ACCESS_TOKEN} from "../../constants/SessionStorage";
 import {Redirect, withRouter} from "react-router-dom";
+import MyLocationButton from "./MyLocationButton";
 
 const WritingPage = (props) => {
   const [step, setStep] = useState(1);
@@ -32,9 +33,13 @@ const WritingPage = (props) => {
                     loadingElement={<div style={{height: `100%`}}/>}
                     containerElement={<div style={{height: WindowSize().height}}/>}
                     mapElement={<div style={{height: `100%`}}/>}
-                    defaultCenter={{lat: props.location.state.lat, lng:  props.location.state.lng}}
                     center={center}
                     setCenter={setCenter}
+        />
+        <MyLocationButton
+            step={step}
+            setCenter={setCenter}
+            myLocation={props.location.state.myLocation}
         />
         <ToStep2Button step={step} setStep={setStep} />
         <WritingStep2Modal

--- a/frontend/rush/src/components/writing/step1/WritingMap.js
+++ b/frontend/rush/src/components/writing/step1/WritingMap.js
@@ -14,18 +14,16 @@ const WritingMap = withScriptjs(withGoogleMap((props) => {
   const [lng, setLng] = useState(null);
 
   useEffect(() => {
-    if (lat == null) {
-      setLat(props.defaultCenter.lat);
-      setLng(props.defaultCenter.lng);
-    }
-  });
+      setLat(props.center.lat);
+      setLng(props.center.lng);
+  },[props.center]);
 
   return (
       <>
         <GoogleMap
             ref={(map) => setMap(map)}
             defaultZoom={16}
-            center={props.defaultCenter}
+            center={{lat: props.center.lat(), lng: props.center.lng()}}
             defaultOptions={{
               disableDefaultUI:true,
               maxZoom:21,
@@ -41,8 +39,6 @@ const WritingMap = withScriptjs(withGoogleMap((props) => {
             }}
             onCenterChanged={() => {
               props.setCenter(map.getCenter());
-              setLat(props.center.lat);
-              setLng(props.center.lng);
             }}
             onZoomChanged={() => {
               props.setCenter(map.getCenter());


### PR DESCRIPTION
**이슈 번호**

resolved: #181 

**작업 내용**

1. 백엔드 범위함수 잘못지정된 lat 을 lng로 수정
2. gps상의 현위치 및 글상세페이지에서 나왔을 시 그 글의 좌표 값을 고려하지 않은 체로 학교주소로 설정된 center로 article들을 가져오는 문제였음, setCenter로 위 두 상황에 대한 좌표 값을 반영하도록 수정
```
      setCenter({
        lat: () => props.location.state? props.location.state.lat: position.coords.latitude,
        lng: () => props.location.state? props.location.state.lng: position.coords.longitude
      });
```
자세한 사항은 defaultCenter.js 코드를 참고 

3. 글쓰기페이지에 들어가면 내가 보고있던 center로 보이도록 수정 및 현위치 버튼 추가

![image](https://user-images.githubusercontent.com/45135492/131101257-19e9636b-31d8-4512-b773-f719658de887.png)

**테스트 작성 여부**

- [ ] Test case

**주의 사항**
위치허용을 허용하지 않으면 현위치 버튼을 누를 시 현위치 대신 defaultCenter 인 학교좌표로 이동