### PR TITLE
refactor: 백앤드 조회기능만 있는 기능을 읽기전용으로 수정 

### DIFF
--- a/backend/rush/src/main/java/rush/rush/domain/Article.java
+++ b/backend/rush/src/main/java/rush/rush/domain/Article.java
@@ -155,4 +155,8 @@ public class Article {
             .anyMatch(articleLike -> articleLike.getId()
                 .equals(newArticleLike.getId()));
     }
+
+    public void changeTitle(String newTitle){
+        this.title = newTitle;
+    }
 }

--- a/backend/rush/src/main/java/rush/rush/repository/ArticleLikeRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/ArticleLikeRepository.java
@@ -1,10 +1,8 @@
 package rush.rush.repository;
 
 import java.util.Optional;
-import javax.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import rush.rush.domain.ArticleLike;
 
@@ -16,7 +14,6 @@ public interface ArticleLikeRepository extends JpaRepository<ArticleLike, Long> 
         + "where articlelike.article.id = :articleId "
         + "and articlelike.article.publicMap = true "
         + "and articlelike.user.id = :userId ")
-    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Long countOfPublicArticle(
         @Param("articleId") Long articleId, @Param("userId") Long userId);
 
@@ -24,7 +21,6 @@ public interface ArticleLikeRepository extends JpaRepository<ArticleLike, Long> 
         + "where articlelike.article.id = :articleId "
         + "and articlelike.article.user.id = :userId "
         + "and articlelike.user.id = :userId ")
-    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Long countOfPrivateArticle(
         @Param("articleId") Long articleId, @Param("userId") Long userId);
 
@@ -37,7 +33,6 @@ public interface ArticleLikeRepository extends JpaRepository<ArticleLike, Long> 
         + "where article.id = :articleId "
         + "and user.id = :userId "
         + "and articlelike.user.id = :userId ")
-    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Long countOfGroupedArticle(
         @Param("articleId") Long articleId, @Param("userId") Long userId);
 }

--- a/backend/rush/src/main/java/rush/rush/repository/ArticleLikeRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/ArticleLikeRepository.java
@@ -1,12 +1,14 @@
 package rush.rush.repository;
 
 import java.util.Optional;
+import javax.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import rush.rush.domain.ArticleLike;
 
-public interface ArticleLikeRepository extends JpaRepository<ArticleLike,Long> {
+public interface ArticleLikeRepository extends JpaRepository<ArticleLike, Long> {
 
     Optional<ArticleLike> findByUserIdAndArticleId(Long userId, Long articleId);
 
@@ -14,6 +16,7 @@ public interface ArticleLikeRepository extends JpaRepository<ArticleLike,Long> {
         + "where articlelike.article.id = :articleId "
         + "and articlelike.article.publicMap = true "
         + "and articlelike.user.id = :userId ")
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Long countOfPublicArticle(
         @Param("articleId") Long articleId, @Param("userId") Long userId);
 
@@ -21,6 +24,7 @@ public interface ArticleLikeRepository extends JpaRepository<ArticleLike,Long> {
         + "where articlelike.article.id = :articleId "
         + "and articlelike.article.user.id = :userId "
         + "and articlelike.user.id = :userId ")
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Long countOfPrivateArticle(
         @Param("articleId") Long articleId, @Param("userId") Long userId);
 
@@ -33,6 +37,7 @@ public interface ArticleLikeRepository extends JpaRepository<ArticleLike,Long> {
         + "where article.id = :articleId "
         + "and user.id = :userId "
         + "and articlelike.user.id = :userId ")
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Long countOfGroupedArticle(
         @Param("articleId") Long articleId, @Param("userId") Long userId);
 }

--- a/backend/rush/src/main/java/rush/rush/repository/ArticleLikeRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/ArticleLikeRepository.java
@@ -1,13 +1,16 @@
 package rush.rush.repository;
 
 import java.util.Optional;
+import javax.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import rush.rush.domain.ArticleLike;
 
 public interface ArticleLikeRepository extends JpaRepository<ArticleLike, Long> {
 
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Optional<ArticleLike> findByUserIdAndArticleId(Long userId, Long articleId);
 
     @Query("select count(articlelike) from ArticleLike articlelike "

--- a/backend/rush/src/main/java/rush/rush/repository/ArticleRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/ArticleRepository.java
@@ -82,8 +82,10 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     Optional<ArticleResponse> findAsGroupMapArticleWithLikes(@Param("articleId") Long articleId,
         @Param("userId") Long userId);
 
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Optional<Article> findByPublicMapTrueAndId(Long articleId);
 
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Optional<Article> findByPrivateMapTrueAndIdAndUserId(Long articleId, Long userId);
 
     @Query("select distinct article from Article article "
@@ -92,6 +94,7 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
         + "inner join g.userGroups usergroup "
         + "inner join usergroup.user groupmember "
         + "where article.id = :articleId and groupmember.id = :userId")
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Optional<Article> findAsGroupMapArticle(@Param("articleId") Long articleId,
         @Param("userId") Long userId);
 
@@ -103,5 +106,6 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     List<Article> findArticlesWithComments(@Param("userId") Long userId);
 
     @Query("select distinct article.user.id from Article article where article.id = :articleId")
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Optional<Long> findArticleAuthorId(@Param("articleId") Long articleId);
 }

--- a/backend/rush/src/main/java/rush/rush/repository/ArticleRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/ArticleRepository.java
@@ -46,7 +46,6 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
         + "left join article.articleLikes articleLikes "
         + "inner join article.user user "
         + "where article.publicMap = true and article.id = :articleId")
-    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Optional<ArticleResponse> findByPublicMapWithLikes(@Param("articleId") Long articleId);
 
     @Query("select distinct new rush.rush.dto.ArticleResponse(article.id, article.title, "
@@ -61,7 +60,6 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
         + "left join article.articleLikes articleLikes "
         + "inner join article.user user "
         + "where article.privateMap = true and article.id = :articleId and user.id = :userId ")
-    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Optional<ArticleResponse> findByPrivateMapWithLikes(@Param("articleId") Long articleId,
         @Param("userId") Long userId);
 
@@ -81,7 +79,6 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
         + "inner join usergroup.user groupmember "
         + "inner join article.user user "
         + "where article.id = :articleId and groupmember.id = :userId ")
-    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Optional<ArticleResponse> findAsGroupMapArticleWithLikes(@Param("articleId") Long articleId,
         @Param("userId") Long userId);
 

--- a/backend/rush/src/main/java/rush/rush/repository/ArticleRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/ArticleRepository.java
@@ -2,8 +2,10 @@ package rush.rush.repository;
 
 import java.util.List;
 import java.util.Optional;
+import javax.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import rush.rush.domain.Article;
 import rush.rush.dto.ArticleResponse;
@@ -12,9 +14,11 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 
     List<Article> findAllByUserId(Long userId);
 
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     List<Article> findAllByPublicMapTrueAndLatitudeBetweenAndLongitudeBetween(
         Double lowerLatitude, Double upperLatitude, Double lowerLongitude, Double upperLongitude);
 
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     List<Article> findAllByPrivateMapTrueAndUserIdAndLatitudeBetweenAndLongitudeBetween(Long userId,
         Double lowerLatitude, Double upperLatitude, Double lowerLongitude, Double upperLongitude);
 
@@ -25,6 +29,7 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
         + "where g.id = :groupId and usergroup.user.id = :userId "
         + "and article.latitude between :lowerLatitude and :upperLatitude "
         + "and article.longitude between :lowerLongitude and :upperLongitude")
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     List<Article> findAllOfGroupedMap(@Param("userId") Long userId, @Param("groupId") Long groupId,
         @Param("lowerLatitude") Double lowerLatitude, @Param("upperLatitude") Double upperLatitude,
         @Param("lowerLongitude") Double lowerLongitude, @Param("upperLongitude") Double upperLongitude);
@@ -41,6 +46,7 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
         + "left join article.articleLikes articleLikes "
         + "inner join article.user user "
         + "where article.publicMap = true and article.id = :articleId")
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Optional<ArticleResponse> findByPublicMapWithLikes(@Param("articleId") Long articleId);
 
     @Query("select distinct new rush.rush.dto.ArticleResponse(article.id, article.title, "
@@ -55,6 +61,7 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
         + "left join article.articleLikes articleLikes "
         + "inner join article.user user "
         + "where article.privateMap = true and article.id = :articleId and user.id = :userId ")
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Optional<ArticleResponse> findByPrivateMapWithLikes(@Param("articleId") Long articleId,
         @Param("userId") Long userId);
 
@@ -74,6 +81,7 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
         + "inner join usergroup.user groupmember "
         + "inner join article.user user "
         + "where article.id = :articleId and groupmember.id = :userId ")
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Optional<ArticleResponse> findAsGroupMapArticleWithLikes(@Param("articleId") Long articleId,
         @Param("userId") Long userId);
 
@@ -94,6 +102,7 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
         + "left join fetch article.articleLikes articleLikes "
         + "where article.user.id = :userId "
         + "order by article.createDate desc")
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     List<Article> findArticlesWithComments(@Param("userId") Long userId);
 
     @Query("select distinct article.user.id from Article article where article.id = :articleId")

--- a/backend/rush/src/main/java/rush/rush/repository/CommentLikeRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/CommentLikeRepository.java
@@ -2,13 +2,16 @@ package rush.rush.repository;
 
 import java.util.List;
 import java.util.Optional;
+import javax.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import rush.rush.domain.CommentLike;
 
 public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
 
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Optional<CommentLike> findByUserIdAndCommentId(Long userId, Long commentId);
 
     @Query("select commentLike.comment.id from CommentLike commentLike "

--- a/backend/rush/src/main/java/rush/rush/repository/CommentLikeRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/CommentLikeRepository.java
@@ -2,8 +2,10 @@ package rush.rush.repository;
 
 import java.util.List;
 import java.util.Optional;
+import javax.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import rush.rush.domain.CommentLike;
 
@@ -16,6 +18,7 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
         + "where article.id = :articleId "
         + "and article.publicMap = true "
         + "and commentLike.user.id = :userId")
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     List<Long> findPublicArticleCommentIdsILiked(
         @Param("articleId") Long articleId, @Param("userId") Long userId);
 
@@ -26,6 +29,7 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
         + "and article.privateMap = true "
         + "and article.user.id = :userId "
         + "and commentLike.user.id = :userId")
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     List<Long> findPrivateArticleCommentIdsILiked(
         @Param("articleId") Long articleId, @Param("userId") Long userId);
 
@@ -38,6 +42,7 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
         + "where article.id = :articleId "
         + "and user.id = :userId "
         + "and commentLike.user.id = :userId ")
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     List<Long> findGroupedArticleCommentIdsILiked(
         @Param("articleId") Long articleId, @Param("userId") Long userId);
 }

--- a/backend/rush/src/main/java/rush/rush/repository/CommentLikeRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/CommentLikeRepository.java
@@ -2,10 +2,8 @@ package rush.rush.repository;
 
 import java.util.List;
 import java.util.Optional;
-import javax.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import rush.rush.domain.CommentLike;
 
@@ -18,7 +16,6 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
         + "where article.id = :articleId "
         + "and article.publicMap = true "
         + "and commentLike.user.id = :userId")
-    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     List<Long> findPublicArticleCommentIdsILiked(
         @Param("articleId") Long articleId, @Param("userId") Long userId);
 
@@ -29,7 +26,6 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
         + "and article.privateMap = true "
         + "and article.user.id = :userId "
         + "and commentLike.user.id = :userId")
-    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     List<Long> findPrivateArticleCommentIdsILiked(
         @Param("articleId") Long articleId, @Param("userId") Long userId);
 
@@ -42,7 +38,6 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
         + "where article.id = :articleId "
         + "and user.id = :userId "
         + "and commentLike.user.id = :userId ")
-    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     List<Long> findGroupedArticleCommentIdsILiked(
         @Param("articleId") Long articleId, @Param("userId") Long userId);
 }

--- a/backend/rush/src/main/java/rush/rush/repository/CommentRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/CommentRepository.java
@@ -2,10 +2,8 @@ package rush.rush.repository;
 
 import java.util.List;
 import java.util.Optional;
-import javax.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import rush.rush.domain.Comment;
 import rush.rush.dto.CommentResponse;
@@ -46,7 +44,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
         + "and comment.article.publicMap = true "
         + "group by comment.id "
         + "order by comment.createDate desc")
-    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     List<CommentResponse> findAllOfPublicArticle(
         @Param("articleId") Long articleId);
 
@@ -66,7 +63,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
         + "and usergroup.user.id = :userId "
         + "group by comment.id "
         + "order by comment.createDate desc")
-    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     List<CommentResponse> findAllOfGroupedArticle(
         @Param("articleId") Long articleId, @Param("userId") Long userId);
 
@@ -83,7 +79,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
         + "and comment.article.user.id = :userId "
         + "group by comment.id "
         + "order by comment.createDate desc")
-    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     List<CommentResponse> findAllOfPrivateArticle(
         @Param("articleId") Long articleId, @Param("userId") Long userId);
 }

--- a/backend/rush/src/main/java/rush/rush/repository/CommentRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/CommentRepository.java
@@ -2,8 +2,10 @@ package rush.rush.repository;
 
 import java.util.List;
 import java.util.Optional;
+import javax.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import rush.rush.domain.Comment;
 import rush.rush.dto.CommentResponse;
@@ -15,11 +17,13 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("select distinct comment from Comment comment "
         + "where comment.id = :commentId "
         + "and comment.article.publicMap = true ")
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Optional<Comment> findInPublicArticle(@Param("commentId") Long commentId);
 
     @Query("select distinct comment from Comment comment "
         + "where comment.id = :commentId "
         + "and comment.article.user.id = :userId ")
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Optional<Comment> findInPrivateArticle(@Param("commentId") Long commentId,
         @Param("userId") Long userId);
 
@@ -29,6 +33,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
         + "inner join g.userGroups usergroup "
         + "inner join usergroup.user groupmember "
         + "where comment.id = :commentId and groupmember.id = :userId")
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Optional<Comment> findInGroupedArticle(@Param("commentId") Long commentId,
         @Param("userId") Long userId);
 

--- a/backend/rush/src/main/java/rush/rush/repository/CommentRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/CommentRepository.java
@@ -2,8 +2,10 @@ package rush.rush.repository;
 
 import java.util.List;
 import java.util.Optional;
+import javax.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import rush.rush.domain.Comment;
 import rush.rush.dto.CommentResponse;
@@ -44,6 +46,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
         + "and comment.article.publicMap = true "
         + "group by comment.id "
         + "order by comment.createDate desc")
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     List<CommentResponse> findAllOfPublicArticle(
         @Param("articleId") Long articleId);
 
@@ -63,6 +66,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
         + "and usergroup.user.id = :userId "
         + "group by comment.id "
         + "order by comment.createDate desc")
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     List<CommentResponse> findAllOfGroupedArticle(
         @Param("articleId") Long articleId, @Param("userId") Long userId);
 
@@ -79,6 +83,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
         + "and comment.article.user.id = :userId "
         + "group by comment.id "
         + "order by comment.createDate desc")
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     List<CommentResponse> findAllOfPrivateArticle(
         @Param("articleId") Long articleId, @Param("userId") Long userId);
 }

--- a/backend/rush/src/main/java/rush/rush/repository/GroupRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/GroupRepository.java
@@ -12,13 +12,13 @@ import rush.rush.domain.Group;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
 
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Optional<Group> findByInvitationCode(String invitationCode);
 
     @Query("select distinct g from Group g "
         + "inner join g.userGroups usergroup "
         + "inner join usergroup.user user "
         + "where user.id = :userId and g.id = :groupId")
-    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Optional<Group> findByGroupIdAndUserId(@Param("groupId") Long groupId, @Param("userId") Long userId);
 
     @Query("select distinct g from Group g "

--- a/backend/rush/src/main/java/rush/rush/repository/GroupRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/GroupRepository.java
@@ -2,9 +2,11 @@ package rush.rush.repository;
 
 import java.util.List;
 import java.util.Optional;
+import javax.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import rush.rush.domain.Group;
 
@@ -16,12 +18,14 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
         + "inner join g.userGroups usergroup "
         + "inner join usergroup.user user "
         + "where user.id = :userId and g.id = :groupId")
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Optional<Group> findByGroupIdAndUserId(@Param("groupId") Long groupId, @Param("userId") Long userId);
 
     @Query("select distinct g from Group g "
         + "inner join g.userGroups usergroup "
         + "inner join usergroup.user user "
         + "where user.id = :userId")
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     List<Group> findAllByUserId(@Param("userId") Long userId);
 
     @Modifying

--- a/backend/rush/src/main/java/rush/rush/repository/UserGroupRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/UserGroupRepository.java
@@ -12,11 +12,11 @@ import rush.rush.domain.UserGroup;
 
 public interface UserGroupRepository extends JpaRepository<UserGroup, Long> {
 
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     List<UserGroup> findAllByUserId(Long userId);
 
     List<UserGroup> findAllByGroupId(Long userId);
 
-    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Optional<UserGroup> findByUserIdAndGroupId(Long userId, Long groupId);
 
     @Modifying

--- a/backend/rush/src/main/java/rush/rush/repository/UserGroupRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/UserGroupRepository.java
@@ -2,9 +2,11 @@ package rush.rush.repository;
 
 import java.util.List;
 import java.util.Optional;
+import javax.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import rush.rush.domain.UserGroup;
 
@@ -14,6 +16,7 @@ public interface UserGroupRepository extends JpaRepository<UserGroup, Long> {
 
     List<UserGroup> findAllByGroupId(Long userId);
 
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     Optional<UserGroup> findByUserIdAndGroupId(Long userId, Long groupId);
 
     @Modifying

--- a/backend/rush/src/main/java/rush/rush/repository/UserRepository.java
+++ b/backend/rush/src/main/java/rush/rush/repository/UserRepository.java
@@ -2,8 +2,10 @@ package rush.rush.repository;
 
 import java.util.List;
 import java.util.Optional;
+import javax.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import rush.rush.domain.User;
 
@@ -17,5 +19,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
         + "inner join user.userGroups usergroups "
         + "inner join usergroups.group g "
         + "where g.id = :groupId")
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     List<User> findAllByGroupId(@Param("groupId") Long groupId);
 }

--- a/backend/rush/src/main/java/rush/rush/service/article/ArticleLikeService.java
+++ b/backend/rush/src/main/java/rush/rush/service/article/ArticleLikeService.java
@@ -30,7 +30,7 @@ public class ArticleLikeService {
         }
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public boolean hasILiked(Long articleId, MapType mapType, Long userId) {
         if (mapType == MapType.PUBLIC) {
             return articleLikeRepository.countOfPublicArticle(articleId, userId) >=1;

--- a/backend/rush/src/main/java/rush/rush/service/article/FindArticleService.java
+++ b/backend/rush/src/main/java/rush/rush/service/article/FindArticleService.java
@@ -20,7 +20,7 @@ public class FindArticleService {
 
     private final ArticleRepository articleRepository;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public ArticleResponse findPublicArticle(Long id) {
         ArticleResponse articleResponse = articleRepository.findByPublicMapWithLikes(id)
             .orElseThrow(() ->
@@ -29,7 +29,7 @@ public class FindArticleService {
         return articleResponse;
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public ArticleResponse findPrivateArticle(Long id, User me) {
         ArticleResponse articleResponse = articleRepository
             .findByPrivateMapWithLikes(id, me.getId())
@@ -39,7 +39,7 @@ public class FindArticleService {
         return articleResponse;
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public ArticleResponse findGroupArticle(Long id, User me) {
         ArticleResponse articleResponse = articleRepository
             .findAsGroupMapArticleWithLikes(id, me.getId())
@@ -49,7 +49,7 @@ public class FindArticleService {
         return articleResponse;
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<ArticleSummaryResponse> findPublicMapArticles(
         Double latitude, Double latitudeRange, Double longitude, Double longitudeRange) {
         LocationRange locationRange = new LocationRange(latitude, latitudeRange, longitude,
@@ -63,7 +63,7 @@ public class FindArticleService {
         return toResponses(articles);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<ArticleSummaryResponse> findPrivateMapArticles(Double latitude,
         Double latitudeRange, Double longitude, Double longitudeRange, User me) {
         LocationRange locationRange = new LocationRange(latitude, latitudeRange, longitude,
@@ -77,7 +77,7 @@ public class FindArticleService {
         return toResponses(articles);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<ArticleSummaryResponse> findGroupedMapArticles(Long groupId,
         Double latitude, Double latitudeRange, Double longitude, Double longitudeRange, User user) {
         LocationRange locationRange = new LocationRange(latitude, latitudeRange, longitude,

--- a/backend/rush/src/main/java/rush/rush/service/article/FindMyArticlesService.java
+++ b/backend/rush/src/main/java/rush/rush/service/article/FindMyArticlesService.java
@@ -15,7 +15,7 @@ public class FindMyArticlesService {
 
     final private ArticleRepository articleRepository;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<MyPageArticleResponse> findMyArticles(Long userId) {
         List<Article> articles = articleRepository.findArticlesWithComments(userId);
 

--- a/backend/rush/src/main/java/rush/rush/service/comment/CommentLikeService.java
+++ b/backend/rush/src/main/java/rush/rush/service/comment/CommentLikeService.java
@@ -29,7 +29,7 @@ public class CommentLikeService {
         }
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<Long> hasILiked(Long articleId, MapType mapType, Long userId) {
         if (mapType == MapType.PUBLIC) {
             return commentLikeRepository.findPublicArticleCommentIdsILiked(articleId, userId);

--- a/backend/rush/src/main/java/rush/rush/service/comment/FindCommentService.java
+++ b/backend/rush/src/main/java/rush/rush/service/comment/FindCommentService.java
@@ -14,17 +14,17 @@ public class FindCommentService {
 
     private final CommentRepository commentRepository;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<CommentResponse> findCommentsOfPublicArticle(Long articleId) {
         return commentRepository.findAllOfPublicArticle(articleId);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<CommentResponse> findCommentsOfPrivateArticle(Long articleId, User user) {
         return commentRepository.findAllOfPrivateArticle(articleId, user.getId());
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<CommentResponse> findCommentsOfGroupedArticle(Long articleId, User user) {
         return commentRepository.findAllOfGroupedArticle(articleId, user.getId());
     }

--- a/backend/rush/src/main/java/rush/rush/service/group/FindGroupService.java
+++ b/backend/rush/src/main/java/rush/rush/service/group/FindGroupService.java
@@ -24,7 +24,7 @@ public class FindGroupService {
     private final UserGroupRepository userGroupRepository;
     private final UserRepository userRepository;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<GroupSummaryResponse> findAllByUser(User user) {
         List<Group> groups = groupRepository.findAllByUserId(user.getId());
 
@@ -33,7 +33,7 @@ public class FindGroupService {
             .collect(Collectors.toUnmodifiableList());
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public GroupResponse findOne(Long groupId, User user) {
         Group group = groupRepository.findByGroupIdAndUserId(groupId, user.getId())
             .orElseThrow(() -> new IllegalArgumentException("해당 그룹이 없거나, "
@@ -41,7 +41,7 @@ public class FindGroupService {
         return new GroupResponse(group.getId(), group.getName(), group.getInvitationCode(), group.getCreateDate());
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<SimpleUserResponse> findMembers(Long groupId, User user) {
         if (!hasJoined(groupId, user.getId())) {
             throw new IllegalArgumentException("userId=" + user.getId() + "인 사용자가 "


### PR DESCRIPTION
**이슈 번호**

resolved: #202 

**작업 내용**

1. service 조회 기능만을 수행하는 transactional에 readOnly를 달아서 읽기전용으로 수정(flush가 일어나지 않으며 시간 측면에서 성능 향상)
2. 데이터를 조회용도로만 사용하는 repository 메서드에 쿼리힌트로 readOnly를 적용하여 읽기전용으로 수정(엔티티 컨텍스트에 repository 메서드를 통해 찾은 엔티티가 등록되지 않으면서 메모리 측면에서 성능 향상)

**테스트 작성 여부**

- [X] Test case

**주의 사항**
1. transactional 에 readOnly 옵션을 달았지만 H2 db에서는 transactional에 readOnly 옵션이 적용이 되지가 않아서 테스트는 해보지 못함. mysql 에서는 적용되니 실서버에서는 적용될듯
2.  엔티티가 아닌 스칼라로 select를 진행하는 repository 메서드는 readOnly 옵션을 적용하지 않아도 자동으로 적용되니 옵션 적용 안함
3. 쿼리힌트를 통해 readOnly를 적용했을 시 스냅샷만 저장하지 않는 것이지, 1차 캐시에는 그대로 저장되므로 fetch join 과 같이 1차 캐시를 이용하는 곳에 적용해도 상관x
4. 현재 프로젝트에서 service가 조회기능을 하는 곳에서 사용되는 repository 메서드만을 readOnly옵션을 추가함. 하지만 create, delete를 진행하는 service에 사용되는 곳에서 find를 수행하는 repository 메서드에 readOnly옵션을 추가해도 문제가 생기지 않기에 더 추가할 예정. 추가한 후 이 주의 사항은 지우겠음.