### PR TITLE
feat: 댓글 관련 세부 기능 개선

### DIFF
--- a/frontend/rush/src/api/comment/DeleteCommentApi.js
+++ b/frontend/rush/src/api/comment/DeleteCommentApi.js
@@ -16,7 +16,7 @@ const deleteCommentApi = ({ commentId, accessToken, history }) => {
   .then(response => {
     if (response.status === 204) {
       alert("댓글이 삭제되었습니다 :)");
-      history.push("/");
+      window.location.reload();
     }
   })
   .catch(error => {

--- a/frontend/rush/src/components/articleDetail/Comment.js
+++ b/frontend/rush/src/components/articleDetail/Comment.js
@@ -7,7 +7,7 @@ import deleteCommentApi from "../../api/comment/DeleteCommentApi";
 
 const CommentBox = styled.div`
   margin: 0;
-  height: 100px;
+  min-height: 100px;
   border-bottom: 2px solid rgb(90, 155, 213);
   padding: 15px 10px 0 10px;
   display: flex;
@@ -112,7 +112,7 @@ const Comment = ({
         <AuthorName>
           {comment.author.nickName}
         </AuthorName>
-        <div>{comment.content}</div>
+        <div>{comment.content.split('\n').map((line) => {return (<>{line}<br/></>)})}</div>
         <CommentBottom>
           <CommentLike>
             <CommentLikeInner>

--- a/frontend/rush/src/components/articleDetail/CommentWriting.js
+++ b/frontend/rush/src/components/articleDetail/CommentWriting.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState, useCallback, useRef} from 'react';
 import styled from "styled-components";
 import createCommentApi from "../../api/comment/CreateCommentApi";
 
@@ -10,14 +10,16 @@ const StyledDiv = styled.div`
   border-bottom: 2px solid rgb(90, 155, 213);
 `;
 
-const StyledInput = styled.input`
+const StyledTextarea = styled.textarea`
   display: inline-block;
   font-family: 'Gowun Dodum', sans-serif;
   font-size: 17px;
   background-color: #00000000;
-  padding: 10px;
-  height: 10px;
+  padding: 3px 10px 10px 10px;
+  height: 20px;
+  max-height: 80px;
   width: 100%;
+  resize: none;
 `;
 
 const CommentWritingButton = styled.button`
@@ -40,13 +42,28 @@ const CommentWritingButton = styled.button`
 
 const CommentWriting = ({articleId, comments, setComments, mapType, accessToken, history}) => {
   const [inputValue, setInputValue] = useState([]);
+  const writingRef =useRef();
+
+  const handleResizeHeight = useCallback(() => {
+    if (writingRef === null || writingRef.current === null)
+      return;
+    if(writingRef.current.style.height === '20px') {
+      writingRef.current.style.overflow = 'hidden';
+    }
+    else { writingRef.current.style.overflow= '';}
+    writingRef.current.style.height = '20px';
+    writingRef.current.style.height = writingRef.current.scrollHeight-18 + 'px';
+  },[]);
 
   return (
       <StyledDiv>
-        <StyledInput
+        <StyledTextarea
+            ref={writingRef}
             value={inputValue}
-            onChange={e => setInputValue(e.target.value)}
-            type="text"
+            onChange={e => {
+              setInputValue(e.target.value)
+              handleResizeHeight()
+            }}
             placeholder="댓글을 입력해주세요 :)"
         />
         <CommentWritingButton onClick={() => {
@@ -61,6 +78,7 @@ const CommentWriting = ({articleId, comments, setComments, mapType, accessToken,
                 history
             ).then(commentPromise => {
               setComments(new Array(commentPromise).concat(comments))
+              writingRef.current.style.height = '20px';
             })
           };
         }}>


### PR DESCRIPTION

**이슈 번호**

resolved: #216 

**작업 내용**

1. 댓글 삭제시 홈이 아니라 보고있던 게시글 페이지로 리로드
2. 댓글 길이가 길 경우 댓글칸이 길어지도록 수정(댓글 길이에 따라 높이가 결정, height대신 min-height 사용)
3. 댓글 입력을 input대신 textarea로 변경, 개행을 할 수 있도록하며 개행에 따라 높이 자동조정
4. 댓글도 줄바꿈이 표시되도록 수정

![image](https://user-images.githubusercontent.com/45135492/135056804-e30fdbc7-6a52-4c24-99d1-78d995dd145e.png)  ![image](https://user-images.githubusercontent.com/45135492/135056877-d230f0e7-aa62-4747-afad-dd73a0dedcfd.png)


**테스트 작성 여부**

- [ ] Test case

**주의 사항**