### PR TITLE
refactor: 마이페이지 게시글찾아올 때 발생하는 N+1 문제 수정

### DIFF
--- a/backend/rush/src/main/resources/application-local.yml
+++ b/backend/rush/src/main/resources/application-local.yml
@@ -19,4 +19,3 @@ spring:
         format_sql: true
         default_batch_fetch_size: 1000
     show-sql: true
-

--- a/backend/rush/src/main/resources/application-local.yml
+++ b/backend/rush/src/main/resources/application-local.yml
@@ -17,4 +17,6 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        default_batch_fetch_size: 1000
     show-sql: true
+


### PR DESCRIPTION
**이슈 번호**

resolved: #220 

**작업 내용**

1. 한번에 가져오는 데이터를 처음에 가져오는 부모의 id 수가 최대 1000개까지 자식을 가져오도록 설정(N+1문제를 1+1 로 변경)

**테스트 작성 여부**

- [ ] Test case

**주의 사항**
배포환경에서는 real에 추가할 예정