### PR TITLE
fix: 맵 초기화 시 현재 위치를 못받아오는 문제해결

### DIFF
--- a/frontend/rush/src/components/home/DefaultMapPage.js
+++ b/frontend/rush/src/components/home/DefaultMapPage.js
@@ -52,14 +52,21 @@ const DefaultMapPage = (props) => {
   const [isGroupOpened, setIsGroupOpened] = useState(false);
 
   useEffect(() => {
-    navigator.geolocation.getCurrentPosition(function (position) {
-      setDefaultCenter({lat: position.coords.latitude, lng: position.coords.longitude});
-    });
-    setCenter({
-      lat: () => props.location.state? props.location.state.lat: defaultCenter.lat,
-      lng: () => props.location.state? props.location.state.lng: defaultCenter.lng
-    });
-
+    navigator.geolocation.getCurrentPosition(
+      function success(position) {
+        setDefaultCenter({lat: position.coords.latitude, lng: position.coords.longitude});
+        setCenter({
+          lat: () => props.location.state ? props.location.state.lat : position.coords.latitude,
+          lng: () => props.location.state ? props.location.state.lng : position.coords.longitude
+        });
+      },
+      function failure() {
+        setCenter({
+          lat: () => props.location.state ? props.location.state.lat : defaultCenter.lat,
+          lng: () => props.location.state ? props.location.state.lng : defaultCenter.lng
+        });
+      }
+    );
   },[]);
 
   useEffect(() => {
@@ -107,6 +114,7 @@ const DefaultMapPage = (props) => {
     })
   }, [accessToken]);
 
+  console.log(center.lat() + " " + center.lng())
   return (<>
     <DefaultMap googleMapURL={CLIENT_ID}
                 loadingElement={<div style={{width: `100%`}}/>}

--- a/frontend/rush/src/components/home/menu/Menu.js
+++ b/frontend/rush/src/components/home/menu/Menu.js
@@ -80,8 +80,9 @@ const Menu = ({
                     right: "10px",
                     width: "40px",
                     height: "20px",
-                    marginTop: "4px",
-                    cursor: "pointer"
+                    margin: "0 -20px 0 0",
+                    padding: "5px 10px 5px 10px",
+                    cursor: "pointer",
                   }}
                   onClick={()=>history.push("/groups/" + importantGroup.id)}
               />

--- a/frontend/rush/src/components/home/menu/group/GroupContent.js
+++ b/frontend/rush/src/components/home/menu/group/GroupContent.js
@@ -34,8 +34,9 @@ const GroupContent = ({setIsMenuOpen, groupName, groupId, setMapType, setGroupId
         right: "10px",
         width: "40px",
         height: "20px",
-        marginTop: "4px",
-        cursor: "pointer"
+        margin: "0 -20px 0 0",
+        padding: "5px 10px 5px 10px",
+        cursor: "pointer",
       }}
       onClick={()=>history.push("/groups/" + groupId)}
   /></StyledDiv>


### PR DESCRIPTION
**이슈 번호**

resolved: #223 

**작업 내용**

1.  현위치를 받아오는 함수 안으로 setCenter를 옮김
2. 그룹상세가기버튼의 공간을 넖혀서 버튼 주변을 클릭해도 작동되도록 함

**테스트 작성 여부**

- [ ] Test case

**주의 사항**